### PR TITLE
fix(search): prevent repeated query navigation

### DIFF
--- a/src/hooks/useSearchInput.test.ts
+++ b/src/hooks/useSearchInput.test.ts
@@ -1,0 +1,61 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  getSearchQuery,
+  shouldNavigateToSearch,
+  shouldSyncSearchInput,
+} from './useSearchInput.utils';
+
+describe('getSearchQuery', () => {
+  it('accepts only scalar query values', () => {
+    strictEqual(getSearchQuery('alien'), 'alien');
+    strictEqual(getSearchQuery(['alien', 'aliens']), '');
+    strictEqual(getSearchQuery(undefined), '');
+  });
+});
+
+describe('shouldNavigateToSearch', () => {
+  it('does not navigate again when the URL already has the search query', () => {
+    strictEqual(
+      shouldNavigateToSearch('/search', 'alien', 'alien', true),
+      false
+    );
+  });
+
+  it('navigates when a new debounced query is ready', () => {
+    strictEqual(
+      shouldNavigateToSearch('/search', 'alien', 'aliens', true),
+      true
+    );
+  });
+
+  it('does not navigate for a closed or empty search', () => {
+    strictEqual(shouldNavigateToSearch('/', '', 'alien', false), false);
+    strictEqual(shouldNavigateToSearch('/', '', '', true), false);
+  });
+});
+
+describe('shouldSyncSearchInput', () => {
+  it('does not overwrite typing with the stale route query', () => {
+    strictEqual(shouldSyncSearchInput('/', '', 'a', '', true), false);
+    strictEqual(
+      shouldSyncSearchInput('/search', 'alien', 'aliens', 'alien', true),
+      false
+    );
+  });
+
+  it('syncs a settled input after an external route change', () => {
+    strictEqual(
+      shouldSyncSearchInput('/search', 'aliens', 'alien', 'alien', false),
+      true
+    );
+  });
+
+  it('does not restore the route query while search is being closed', () => {
+    strictEqual(shouldSyncSearchInput('/search', 'alien', '', '', true), false);
+  });
+
+  it('syncs a query when navigating to search externally', () => {
+    strictEqual(shouldSyncSearchInput('/search', 'alien', '', '', false), true);
+  });
+});

--- a/src/hooks/useSearchInput.test.ts
+++ b/src/hooks/useSearchInput.test.ts
@@ -1,10 +1,61 @@
 import { strictEqual } from 'node:assert';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
+import type { NextRouter } from 'next/router';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import useSearchInput from './useSearchInput';
 import {
   getSearchQuery,
   shouldNavigateToSearch,
   shouldSyncSearchInput,
 } from './useSearchInput.utils';
+
+let root: Root | undefined;
+let dom: JSDOM | undefined;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = undefined;
+  }
+  dom?.window.close();
+  dom = undefined;
+});
+
+const createRouter = (overrides: Partial<NextRouter>): NextRouter =>
+  ({
+    asPath: '/search?query=alien',
+    basePath: '',
+    beforePopState: () => undefined,
+    back: () => undefined,
+    defaultLocale: undefined,
+    domainLocales: undefined,
+    events: { emit: () => undefined, off: () => undefined, on: () => undefined },
+    isFallback: false,
+    isLocaleDomain: false,
+    isPreview: false,
+    isReady: true,
+    locale: undefined,
+    locales: undefined,
+    pathname: '/search',
+    prefetch: async () => undefined,
+    push: async () => true,
+    query: { query: 'alien' },
+    reload: () => undefined,
+    replace: async () => true,
+    route: '/search',
+    ...overrides,
+  }) as NextRouter;
+
+const RouterProvider = ({
+  router,
+  children,
+}: {
+  router: NextRouter;
+  children?: ReactNode;
+}) => createElement(RouterContext.Provider, { value: router }, children);
 
 describe('getSearchQuery', () => {
   it('accepts only scalar query values', () => {
@@ -57,5 +108,62 @@ describe('shouldSyncSearchInput', () => {
 
   it('syncs a query when navigating to search externally', () => {
     strictEqual(shouldSyncSearchInput('/search', 'alien', '', '', false), true);
+  });
+});
+
+describe('useSearchInput routing', () => {
+  it('preserves newer typing through a stale route update and navigates once', async () => {
+    dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/search' });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: dom.window,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: dom.window.document,
+    });
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+      .IS_REACT_ACT_ENVIRONMENT = true;
+
+    const replacements: unknown[] = [];
+    const router = createRouter({
+      replace: async (...args) => {
+        replacements.push(args);
+        return true;
+      },
+    });
+    let search: ReturnType<typeof useSearchInput> | undefined;
+    const Probe = () => {
+      search = useSearchInput();
+      return null;
+    };
+    const render = () =>
+      root?.render(
+        createElement(
+          RouterProvider,
+          { router },
+          createElement(Probe)
+        )
+      );
+
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () => render());
+    await act(async () => search?.setSearchValue('aliens'));
+
+    // A completed navigation can still report the previous query while the
+    // user's newer value is waiting for the debounce timer.
+    await act(async () => render());
+    strictEqual(search?.searchValue, 'aliens');
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    strictEqual(replacements.length, 1);
+
+    router.query = { query: 'aliens' };
+    router.asPath = '/search?query=aliens';
+    await act(async () => render());
+    strictEqual(search?.searchValue, 'aliens');
+    strictEqual(replacements.length, 1);
   });
 });

--- a/src/hooks/useSearchInput.ts
+++ b/src/hooks/useSearchInput.ts
@@ -1,9 +1,14 @@
 import type { Nullable } from '@app/utils/typeHelpers';
 import { useRouter } from 'next/router';
 import type { Dispatch, SetStateAction } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { UrlObject } from 'url';
 import useDebouncedState from './useDebouncedState';
+import {
+  getSearchQuery,
+  shouldNavigateToSearch,
+  shouldSyncSearchInput,
+} from './useSearchInput.utils';
 
 type Url = string | UrlObject;
 
@@ -19,9 +24,12 @@ const useSearchInput = (): SearchObject => {
   const router = useRouter();
   const [searchOpen, setIsOpen] = useState(false);
   const [lastRoute, setLastRoute] = useState<Nullable<Url>>(null);
+  const pendingSearchQuery = useRef<Nullable<string>>(null);
+  const closingSearch = useRef(false);
   const [searchValue, debouncedValue, setSearchValue] = useDebouncedState(
-    (router.query.query as string) ?? ''
+    getSearchQuery(router.query.query)
   );
+  const routeQuery = getSearchQuery(router.query.query);
 
   /**
    * This effect handles routing when the debounced search input
@@ -31,18 +39,32 @@ const useSearchInput = (): SearchObject => {
    * in a new route. If we are, then we only replace the history.
    */
   useEffect(() => {
-    if (debouncedValue !== '' && searchOpen) {
+    if (
+      shouldNavigateToSearch(
+        router.pathname,
+        routeQuery,
+        debouncedValue,
+        searchOpen
+      ) &&
+      pendingSearchQuery.current !== debouncedValue
+    ) {
+      pendingSearchQuery.current = debouncedValue;
+
       if (router.pathname.startsWith('/search')) {
-        router.replace({
-          pathname: router.pathname,
-          query: {
-            ...router.query,
-            query: debouncedValue,
+        void router.replace(
+          {
+            pathname: router.pathname,
+            query: {
+              ...router.query,
+              query: debouncedValue,
+            },
           },
-        });
+          undefined,
+          { shallow: true }
+        );
       } else {
         setLastRoute(router.asPath);
-        router
+        void router
           .push({
             pathname: '/search',
             query: { query: debouncedValue },
@@ -50,7 +72,7 @@ const useSearchInput = (): SearchObject => {
           .then(() => window.scrollTo(0, 0));
       }
     }
-  }, [debouncedValue, router, searchOpen]);
+  }, [debouncedValue, routeQuery, router, router.pathname, searchOpen]);
 
   /**
    * This effect is handling behavior when the search input is closed.
@@ -64,6 +86,9 @@ const useSearchInput = (): SearchObject => {
       router.pathname.startsWith('/search') &&
       !searchOpen
     ) {
+      closingSearch.current = true;
+      pendingSearchQuery.current = null;
+
       if (lastRoute) {
         router.push(lastRoute).then(() => window.scrollTo(0, 0));
       } else {
@@ -88,24 +113,45 @@ const useSearchInput = (): SearchObject => {
    * is on /search
    */
   useEffect(() => {
-    if (router.query.query !== debouncedValue) {
-      setSearchValue(
-        router.query.query
-          ? decodeURIComponent(router.query.query as string)
-          : ''
-      );
+    if (!router.pathname.startsWith('/search')) {
+      closingSearch.current = false;
+    }
 
-      if (!router.pathname.startsWith('/search') && !router.query.query) {
+    if (pendingSearchQuery.current !== null) {
+      if (routeQuery === pendingSearchQuery.current) {
+        pendingSearchQuery.current = null;
+      }
+    } else if (
+      shouldSyncSearchInput(
+        router.pathname,
+        routeQuery,
+        searchValue,
+        debouncedValue,
+        closingSearch.current
+      )
+    ) {
+      setSearchValue(routeQuery);
+
+      if (!router.pathname.startsWith('/search') && !routeQuery) {
         setIsOpen(false);
       }
     }
 
-    if (router.pathname.startsWith('/search')) {
+    if (router.pathname.startsWith('/search') && !closingSearch.current) {
       setIsOpen(true);
     }
-  }, [debouncedValue, router, setSearchValue]);
+  }, [
+    debouncedValue,
+    routeQuery,
+    router.pathname,
+    searchOpen,
+    searchValue,
+    setSearchValue,
+  ]);
 
   const clear = useCallback(() => {
+    closingSearch.current = true;
+    pendingSearchQuery.current = null;
     setIsOpen(false);
     setSearchValue('');
   }, [setSearchValue]);

--- a/src/hooks/useSearchInput.ts
+++ b/src/hooks/useSearchInput.ts
@@ -1,4 +1,3 @@
-import type { Nullable } from '@app/utils/typeHelpers';
 import { useRouter } from 'next/router';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -23,8 +22,8 @@ interface SearchObject {
 const useSearchInput = (): SearchObject => {
   const router = useRouter();
   const [searchOpen, setIsOpen] = useState(false);
-  const [lastRoute, setLastRoute] = useState<Nullable<Url>>(null);
-  const pendingSearchQuery = useRef<Nullable<string>>(null);
+  const [lastRoute, setLastRoute] = useState<Url | null>(null);
+  const pendingSearchQuery = useRef<string | null>(null);
   const closingSearch = useRef(false);
   const [searchValue, debouncedValue, setSearchValue] = useDebouncedState(
     getSearchQuery(router.query.query)

--- a/src/hooks/useSearchInput.utils.ts
+++ b/src/hooks/useSearchInput.utils.ts
@@ -1,0 +1,23 @@
+export const getSearchQuery = (query: string | string[] | undefined): string =>
+  typeof query === 'string' ? query : '';
+
+export const shouldNavigateToSearch = (
+  pathname: string,
+  currentQuery: string,
+  nextQuery: string,
+  searchOpen: boolean
+): boolean =>
+  searchOpen &&
+  nextQuery !== '' &&
+  (!pathname.startsWith('/search') || currentQuery !== nextQuery);
+
+export const shouldSyncSearchInput = (
+  pathname: string,
+  routeQuery: string,
+  searchValue: string,
+  debouncedValue: string,
+  closingSearch: boolean
+): boolean =>
+  routeQuery !== searchValue &&
+  searchValue === debouncedValue &&
+  !(pathname.startsWith('/search') && closingSearch);


### PR DESCRIPTION
## Description

The header search input had two URL synchronization effects that could fight each other. A completed route update could copy an older query back into the input, and the navigation effect could call `router.replace` even when the route query already matched.

This change guards identical navigation, tracks in-flight query updates, waits for the local debounce to settle before accepting external route state, uses shallow replacement while already on `/search`, and preserves clear and deep-link behavior. The routing decisions are separated into small helpers with focused regression tests.

**AI Disclosure:** Codex was used to investigate the bug, implement the fix and tests, validate the build, and draft this PR. The contributor requested submission after the combined build was deployed to their Kubernetes environment.

## How Has This Been Tested?

- `pnpm test src/hooks/useSearchInput.test.ts`
- ESLint on the changed search hook, helpers, and tests
- `pnpm typecheck`
- Full suite: 627 tests passed; one unrelated movie-discovery test hit a transient HTTP parser error and passed when rerun alone
- Successful production Docker build from the combined `develop` branch
- The combined image was deployed by digest and reached Kubernetes readiness with zero restarts

## Screenshots / Logs (if applicable)

Not included. The bug is input timing and route synchronization behavior that is covered by the regression tests.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are required for this bug fix.
- [x] All new and existing tests passed. One unrelated full-suite transport failure passed on isolated rerun.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` — no translation keys were changed.
- [x] Database migration (if required) — no database migration is required.
