### PR TITLE
fix(settings): repair Bookshelf add form

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -598,6 +598,27 @@ components:
         externalUrl:
           type: string
           nullable: true
+    ServarrConnectionSettings:
+      type: object
+      properties:
+        hostname:
+          type: string
+          example: '127.0.0.1'
+        port:
+          type: number
+          example: 8787
+        apiKey:
+          type: string
+          example: 'exampleapikey'
+        useSsl:
+          type: boolean
+          example: false
+        baseUrl:
+          type: string
+      required:
+        - hostname
+        - port
+        - apiKey
     RadarrSettings:
       type: object
       properties:
@@ -7400,7 +7421,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ReadarrSettings'
+              $ref: '#/components/schemas/ServarrConnectionSettings'
       responses:
         '200':
           description: Bookshelf connection details returned
@@ -7419,9 +7440,15 @@ paths:
           application/json:
             schema:
               allOf:
-                - $ref: '#/components/schemas/ReadarrSettings'
+                - $ref: '#/components/schemas/ServarrConnectionSettings'
                 - type: object
                   properties:
+                    activeDirectory:
+                      type: string
+                    activeProfileId:
+                      type: number
+                    activeMetadataProfileId:
+                      type: number
                     term:
                       type: string
                       example: isbn:9780547928227

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -601,6 +601,8 @@ components:
     ServarrConnectionSettings:
       type: object
       properties:
+        id:
+          type: number
         hostname:
           type: string
           example: '127.0.0.1'

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -104,7 +104,10 @@ const normalizeConfiguredServiceUrl = (value: string, apiName: string) => {
 };
 
 class ServarrBase<QueueItemAppendT> extends ExternalAPI {
-  static buildUrl(settings: DVRSettings, path?: string): string {
+  static buildUrl(
+    settings: Pick<DVRSettings, 'useSsl' | 'hostname' | 'port' | 'baseUrl'>,
+    path?: string
+  ): string {
     return buildServiceUrl({
       useSsl: settings.useSsl,
       hostname: settings.hostname,

--- a/server/routes/service.test.ts
+++ b/server/routes/service.test.ts
@@ -519,6 +519,47 @@ describe('Bookshelf settings routes', () => {
     assert.match(res.body.message, /settings must be an object/i);
   });
 
+  it('tests a Bookshelf connection before the add form is complete', async () => {
+    mock.method(ReadarrAPI.prototype, 'getSystemStatus', async () => ({
+      appName: 'Bookshelf',
+      version: '0.4.20.129',
+      urlBase: '/bookshelf',
+    }));
+    mock.method(ReadarrAPI.prototype, 'getDevelopmentConfig', async () => ({
+      id: 1,
+      metadataSource: 'https://api.hardcover.app',
+    }));
+    mock.method(ReadarrAPI.prototype, 'getProfiles', async () => [
+      { id: 1, name: 'eBook' },
+    ]);
+    mock.method(ReadarrAPI.prototype, 'getMetadataProfiles', async () => [
+      { id: 2, name: 'Standard' },
+    ]);
+    mock.method(ReadarrAPI.prototype, 'getRootFolders', async () => [
+      {
+        id: 3,
+        path: '/books',
+        freeSpace: 1,
+        totalSpace: 1,
+        unmappedFolders: [],
+      },
+    ]);
+    const res = await request(app).post('/settings/readarr/test').send({
+      hostname: 'bookshelf.local',
+      port: 8787,
+      apiKey: 'test-key',
+      useSsl: false,
+    });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.urlBase, '/bookshelf');
+    assert.deepStrictEqual(res.body.profiles, [{ id: 1, name: 'eBook' }]);
+    assert.deepStrictEqual(res.body.metadataProfiles, [
+      { id: 2, name: 'Standard' },
+    ]);
+    assert.deepStrictEqual(res.body.rootFolders, [{ id: 3, path: '/books' }]);
+  });
+
   it('rejects malformed settings IDs before update lookup', async () => {
     getSettings().readarr = [makeReadarr({ id: 7 })];
 
@@ -745,9 +786,12 @@ describe('Bookshelf settings routes', () => {
     ]);
     mock.method(ReadarrAPI.prototype, 'lookupBook', async () => []);
 
-    const res = await request(app)
-      .post('/settings/readarr/diagnose')
-      .send(makeReadarr({ activeDirectory: '/books' }));
+    const res = await request(app).post('/settings/readarr/diagnose').send({
+      hostname: 'bookshelf.local',
+      port: 8787,
+      apiKey: 'test-key',
+      useSsl: false,
+    });
 
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.body.ok, false);

--- a/server/routes/service.test.ts
+++ b/server/routes/service.test.ts
@@ -593,6 +593,46 @@ describe('Bookshelf settings routes', () => {
     assert.deepStrictEqual(res.body.rootFolders, [{ id: 3, path: '/books' }]);
   });
 
+  it('uses the stored API key when testing an existing Bookshelf', async () => {
+    let apiKeyUsed: string | undefined;
+    getSettings().readarr = [makeReadarr({ id: 7, apiKey: 'stored-key' })];
+    mock.method(
+      ReadarrAPI.prototype,
+      'getSystemStatus',
+      async function (this: ReadarrAPI) {
+        const client = Reflect.get(this, 'axios') as {
+          defaults: { params?: Record<string, string> };
+        };
+        apiKeyUsed = client.defaults.params?.apikey;
+        return {
+          appName: 'Bookshelf',
+          version: '0.4.20.129',
+          urlBase: '',
+        };
+      }
+    );
+    mock.method(ReadarrAPI.prototype, 'getDevelopmentConfig', async () => ({
+      id: 1,
+      metadataSource: 'https://api.hardcover.app',
+    }));
+    mock.method(ReadarrAPI.prototype, 'getProfiles', async () => []);
+    mock.method(ReadarrAPI.prototype, 'getMetadataProfiles', async () => []);
+    mock.method(ReadarrAPI.prototype, 'getRootFolders', async () => []);
+
+    const res = await request(createOpenApiApp())
+      .post('/api/v1/settings/readarr/test')
+      .send({
+        id: 7,
+        hostname: 'bookshelf.local',
+        port: 8787,
+        apiKey: '[REDACTED]',
+        useSsl: false,
+      });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(apiKeyUsed, 'stored-key');
+  });
+
   it('rejects malformed settings IDs before update lookup', async () => {
     getSettings().readarr = [makeReadarr({ id: 7 })];
 

--- a/server/routes/service.test.ts
+++ b/server/routes/service.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 
 import ReadarrAPI from '@server/api/servarr/readarr';
@@ -13,6 +14,7 @@ import type {
 import { getSettings } from '@server/lib/settings';
 import type { Express } from 'express';
 import express from 'express';
+import * as OpenApiValidator from 'express-openapi-validator';
 import request from 'supertest';
 import serviceRoutes from './service';
 import lidarrRoutes from './settings/lidarr';
@@ -74,6 +76,35 @@ function createApp(permissions = Permission.REQUEST_ADVANCED) {
       res
         .status(Number(err.status ?? 500))
         .json({ status: Number(err.status ?? 500), message: err.message });
+    }
+  );
+  return app;
+}
+
+function createOpenApiApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec: path.join(process.cwd(), 'seerr-api.yml'),
+      validateRequests: true,
+      validateSecurity: false,
+    })
+  );
+  app.use('/api/v1/settings/readarr', readarrRoutes);
+  app.use(
+    (
+      err: { status?: number | string; message?: string; errors?: unknown[] },
+      _req: express.Request,
+      res: express.Response,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _next: express.NextFunction
+    ) => {
+      res.status(Number(err.status ?? 500)).json({
+        status: Number(err.status ?? 500),
+        message: err.message,
+        errors: err.errors,
+      });
     }
   );
   return app;
@@ -544,12 +575,14 @@ describe('Bookshelf settings routes', () => {
         unmappedFolders: [],
       },
     ]);
-    const res = await request(app).post('/settings/readarr/test').send({
-      hostname: 'bookshelf.local',
-      port: 8787,
-      apiKey: 'test-key',
-      useSsl: false,
-    });
+    const res = await request(createOpenApiApp())
+      .post('/api/v1/settings/readarr/test')
+      .send({
+        hostname: 'bookshelf.local',
+        port: 8787,
+        apiKey: 'test-key',
+        useSsl: false,
+      });
 
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.body.urlBase, '/bookshelf');

--- a/server/routes/settings/readarr.ts
+++ b/server/routes/settings/readarr.ts
@@ -9,7 +9,11 @@ import {
 } from '@server/utils/bookshelfProvider';
 import { parseNonNegativeRouteId } from '@server/utils/routeId';
 import { preserveRedactedSecrets, redactSecrets } from '@server/utils/security';
-import { parseReadarrSettings } from '@server/utils/servarrSettings';
+import {
+  parseReadarrSettings,
+  parseServarrConnectionSettings,
+  type ServarrConnectionSettings,
+} from '@server/utils/servarrSettings';
 import { Router } from 'express';
 
 const readarrRoutes = Router();
@@ -132,10 +136,10 @@ readarrRoutes.post('/', async (req, res) => {
 readarrRoutes.post<
   undefined,
   Record<string, unknown>,
-  ReadarrSettings & { tagLabel?: string }
+  ServarrConnectionSettings
 >('/test', async (req, res, next) => {
   try {
-    const parsedReadarr = parseReadarrSettings(req.body);
+    const parsedReadarr = parseServarrConnectionSettings(req.body);
 
     if ('error' in parsedReadarr) {
       return res.status(400).json({ message: parsedReadarr.error });
@@ -156,7 +160,6 @@ readarrRoutes.post<
     const profiles = await readarr.getProfiles();
     const metadataProfiles = await readarr.getMetadataProfiles();
     const folders = await readarr.getRootFolders();
-    const tags = await readarr.getTags();
     const provider = classifyBookshelfProvider(development?.metadataSource);
 
     return res.status(200).json({
@@ -166,7 +169,7 @@ readarrRoutes.post<
         id: folder.id,
         path: folder.path,
       })),
-      tags,
+      tags: [],
       urlBase,
       provider,
       legacyWarning: getBookshelfProviderWarning(provider),
@@ -189,7 +192,7 @@ readarrRoutes.post<
     testAdd?: unknown;
   }
 >('/diagnose', async (req, res) => {
-  const parsedReadarr = parseReadarrSettings(req.body);
+  const parsedReadarr = parseServarrConnectionSettings(req.body);
 
   if ('error' in parsedReadarr) {
     return res.status(400).json({
@@ -281,14 +284,21 @@ readarrRoutes.post<
 
     if (testAdd) {
       try {
-        const rootFolder =
-          parsedReadarr.value.activeDirectory || folders[0]?.path;
-        const qualityProfileId =
-          parsedReadarr.value.activeProfileId || profiles[0]?.id;
-        const metadataProfileId =
-          parsedReadarr.value.activeMetadataProfileId ||
-          metadataProfiles[0]?.id ||
-          1;
+        const requestedRootFolder =
+          typeof req.body.activeDirectory === 'string'
+            ? req.body.activeDirectory.trim()
+            : '';
+        const requestedQualityProfileId = Number(req.body.activeProfileId);
+        const requestedMetadataProfileId = Number(
+          req.body.activeMetadataProfileId
+        );
+        const rootFolder = requestedRootFolder || folders[0]?.path;
+        const qualityProfileId = Number.isInteger(requestedQualityProfileId)
+          ? requestedQualityProfileId
+          : profiles[0]?.id;
+        const metadataProfileId = Number.isInteger(requestedMetadataProfileId)
+          ? requestedMetadataProfileId
+          : metadataProfiles[0]?.id || 1;
 
         const added = await readarr.addBook({
           ...addableResult,
@@ -296,7 +306,7 @@ readarrRoutes.post<
           qualityProfileId,
           metadataProfileId,
           rootFolderPath: rootFolder,
-          tags: parsedReadarr.value.tags ?? [],
+          tags: [],
           author: {
             ...addableResult.author,
             rootFolderPath: rootFolder,

--- a/server/routes/settings/readarr.ts
+++ b/server/routes/settings/readarr.ts
@@ -18,6 +18,24 @@ import { Router } from 'express';
 
 const readarrRoutes = Router();
 
+const preserveReadarrConnectionSecret = (body: unknown): unknown => {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return body;
+  }
+
+  const incoming = body as Record<string, unknown>;
+  const id =
+    typeof incoming.id === 'number' && Number.isSafeInteger(incoming.id)
+      ? incoming.id
+      : undefined;
+  const current =
+    id === undefined
+      ? undefined
+      : getSettings().readarr.find((readarr) => readarr.id === id);
+
+  return current ? preserveRedactedSecrets(body, current) : body;
+};
+
 const isAddableBookLookupResult = (result: ReadarrBookLookupResult): boolean =>
   !!(
     result.foreignBookId &&
@@ -139,7 +157,9 @@ readarrRoutes.post<
   ServarrConnectionSettings
 >('/test', async (req, res, next) => {
   try {
-    const parsedReadarr = parseServarrConnectionSettings(req.body);
+    const parsedReadarr = parseServarrConnectionSettings(
+      preserveReadarrConnectionSecret(req.body)
+    );
 
     if ('error' in parsedReadarr) {
       return res.status(400).json({ message: parsedReadarr.error });
@@ -192,7 +212,9 @@ readarrRoutes.post<
     testAdd?: unknown;
   }
 >('/diagnose', async (req, res) => {
-  const parsedReadarr = parseServarrConnectionSettings(req.body);
+  const parsedReadarr = parseServarrConnectionSettings(
+    preserveReadarrConnectionSecret(req.body)
+  );
 
   if ('error' in parsedReadarr) {
     return res.status(400).json({

--- a/server/utils/servarrSettings.ts
+++ b/server/utils/servarrSettings.ts
@@ -23,6 +23,11 @@ const MAX_SERVICE_TAGS = 100;
 const MAX_SERVICE_PORT = 65535;
 const MAX_SERVICE_ID = 1_000_000;
 
+export type ServarrConnectionSettings = Pick<
+  DVRSettings,
+  'hostname' | 'port' | 'apiKey' | 'useSsl' | 'baseUrl'
+>;
+
 const parseNumberArray = (
   value: unknown,
   fieldName: string
@@ -98,6 +103,43 @@ const parseOptionalUrlBase = (
   return normalized || !parsed.value.trim()
     ? { value: normalized || undefined }
     : { error: 'baseUrl must be a relative path.' };
+};
+
+export const parseServarrConnectionSettings = (
+  body: unknown
+): { value: ServarrConnectionSettings } | { error: string } => {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { error: 'settings must be an object.' };
+  }
+
+  const settings = body as Partial<DVRSettings>;
+  const hostname = parseRequiredServiceString(settings.hostname, 'hostname');
+  if ('error' in hostname) return hostname;
+  const normalizedHostname = normalizeServiceHostname(hostname.value);
+  if (!normalizedHostname) {
+    return { error: 'hostname is invalid.' };
+  }
+
+  const apiKey = parseRequiredServiceString(settings.apiKey, 'apiKey');
+  if ('error' in apiKey) return apiKey;
+
+  const port = parseOptionalNonNegativeInteger(settings.port, MAX_SERVICE_PORT);
+  if (port === undefined || port < 1) {
+    return { error: 'port is invalid.' };
+  }
+
+  const baseUrl = parseOptionalUrlBase(settings.baseUrl);
+  if ('error' in baseUrl) return baseUrl;
+
+  return {
+    value: {
+      hostname: normalizedHostname,
+      port,
+      apiKey: apiKey.value,
+      useSsl: parseOptionalBoolean(settings.useSsl) ?? false,
+      baseUrl: baseUrl.value,
+    },
+  };
 };
 
 const parseDvrSettings = (

--- a/server/utils/servarrSettings.ts
+++ b/server/utils/servarrSettings.ts
@@ -26,7 +26,7 @@ const MAX_SERVICE_ID = 1_000_000;
 export type ServarrConnectionSettings = Pick<
   DVRSettings,
   'hostname' | 'port' | 'apiKey' | 'useSsl' | 'baseUrl'
->;
+> & { id?: number };
 
 const parseNumberArray = (
   value: unknown,

--- a/src/components/Settings/ReadarrModal/index.tsx
+++ b/src/components/Settings/ReadarrModal/index.tsx
@@ -29,6 +29,7 @@ const messages = defineMessages('components.Settings.ReadarrModal', {
   validationBaseUrlTrailingSlash: 'URL base must not end in a trailing slash',
   toastReadarrTestSuccess: 'Bookshelf connection established successfully!',
   toastReadarrTestFailure: 'Failed to connect to Bookshelf.',
+  toastReadarrSaveFailure: 'Failed to save the Bookshelf server.',
   add: 'Add Server',
   defaultserver: 'Default Server',
   servername: 'Server Name',
@@ -237,6 +238,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
             autoDismiss: true,
           });
         }
+        return response.data;
       } catch {
         setIsValidated(false);
         setDiagnosticResponse(null);
@@ -246,6 +248,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
             autoDismiss: true,
           });
         }
+        return null;
       } finally {
         setIsTesting(false);
         initialLoad.current = true;
@@ -280,63 +283,70 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
     >
       <Formik
         initialValues={{
-          name: readarr?.name,
-          hostname: readarr?.hostname,
+          name: readarr?.name ?? '',
+          hostname: readarr?.hostname ?? '',
           port: readarr?.port ?? 8787,
           ssl: readarr?.useSsl ?? false,
-          apiKey: readarr?.apiKey,
-          baseUrl: readarr?.baseUrl,
-          activeProfileId: readarr?.activeProfileId,
-          rootFolder: readarr?.activeDirectory,
+          apiKey: readarr?.apiKey ?? '',
+          baseUrl: readarr?.baseUrl ?? '',
+          activeProfileId: readarr?.activeProfileId ?? '',
+          rootFolder: readarr?.activeDirectory ?? '',
           isDefault: readarr?.isDefault ?? false,
-          externalUrl: readarr?.externalUrl,
+          externalUrl: readarr?.externalUrl ?? '',
           syncEnabled: readarr?.syncEnabled ?? false,
           enableSearch: !readarr?.preventSearch,
-          activeMetadataProfileId: readarr?.activeMetadataProfileId ?? 1,
+          activeMetadataProfileId: readarr?.activeMetadataProfileId ?? '',
           serviceType: readarr?.serviceType ?? 'ebook',
         }}
         validationSchema={ReadarrSettingsSchema}
         onSubmit={async (values) => {
-          const profileName = testResponse.profiles.find(
-            (profile) => profile.id === Number(values.activeProfileId)
-          )?.name;
-          const metadataProfileName = testResponse.metadataProfiles.find(
-            (profile) => profile.id === Number(values.activeMetadataProfileId)
-          )?.name;
+          try {
+            const profileName = testResponse.profiles.find(
+              (profile) => profile.id === Number(values.activeProfileId)
+            )?.name;
+            const metadataProfileName = testResponse.metadataProfiles.find(
+              (profile) => profile.id === Number(values.activeMetadataProfileId)
+            )?.name;
 
-          const submission = {
-            name: values.name,
-            hostname: values.hostname,
-            port: Number(values.port),
-            apiKey: values.apiKey,
-            useSsl: values.ssl,
-            baseUrl: values.baseUrl,
-            activeProfileId: Number(values.activeProfileId),
-            activeProfileName: profileName,
-            activeDirectory: values.rootFolder,
-            tags: [],
-            isDefault: values.isDefault,
-            is4k: false,
-            externalUrl: values.externalUrl,
-            syncEnabled: values.syncEnabled,
-            preventSearch: !values.enableSearch,
-            tagRequests: false,
-            overrideRule: [],
-            activeMetadataProfileId: Number(values.activeMetadataProfileId),
-            activeMetadataProfileName: metadataProfileName,
-            serviceType: values.serviceType,
-          };
+            const submission = {
+              name: values.name,
+              hostname: values.hostname,
+              port: Number(values.port),
+              apiKey: values.apiKey,
+              useSsl: values.ssl,
+              baseUrl: values.baseUrl,
+              activeProfileId: Number(values.activeProfileId),
+              activeProfileName: profileName,
+              activeDirectory: values.rootFolder,
+              tags: [],
+              isDefault: values.isDefault,
+              is4k: false,
+              externalUrl: values.externalUrl,
+              syncEnabled: values.syncEnabled,
+              preventSearch: !values.enableSearch,
+              tagRequests: false,
+              overrideRule: [],
+              activeMetadataProfileId: Number(values.activeMetadataProfileId),
+              activeMetadataProfileName: metadataProfileName,
+              serviceType: values.serviceType,
+            };
 
-          if (!readarr) {
-            await axios.post('/api/v1/settings/readarr', submission);
-          } else {
-            await axios.put(
-              `/api/v1/settings/readarr/${readarr.id}`,
-              submission
-            );
+            if (!readarr) {
+              await axios.post('/api/v1/settings/readarr', submission);
+            } else {
+              await axios.put(
+                `/api/v1/settings/readarr/${readarr.id}`,
+                submission
+              );
+            }
+
+            onSave();
+          } catch {
+            addToast(intl.formatMessage(messages.toastReadarrSaveFailure), {
+              appearance: 'error',
+              autoDismiss: true,
+            });
           }
-
-          onSave();
         }}
       >
         {({
@@ -364,17 +374,17 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
                 ? intl.formatMessage(globalMessages.testing)
                 : intl.formatMessage(globalMessages.test)
             }
-            onSecondary={() => {
+            onSecondary={async () => {
               if (values.apiKey && values.hostname && values.port) {
-                testConnection({
+                const response = await testConnection({
                   apiKey: values.apiKey,
                   baseUrl: values.baseUrl,
                   hostname: values.hostname,
                   port: values.port,
                   useSsl: values.ssl,
                 });
-                if (!values.baseUrl || values.baseUrl === '/') {
-                  setFieldValue('baseUrl', testResponse.urlBase);
+                if (response && (!values.baseUrl || values.baseUrl === '/')) {
+                  setFieldValue('baseUrl', response.urlBase || '');
                 }
               }
             }}
@@ -535,7 +545,6 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
                       name="name"
                       type="text"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        setIsValidated(false);
                         setFieldValue('name', e.target.value);
                       }}
                     />

--- a/src/components/Settings/ReadarrModal/index.tsx
+++ b/src/components/Settings/ReadarrModal/index.tsx
@@ -191,12 +191,14 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
 
   const testConnection = useCallback(
     async ({
+      id,
       hostname,
       port,
       apiKey,
       baseUrl,
       useSsl = false,
     }: {
+      id?: number;
       hostname: string;
       port: number;
       apiKey: string;
@@ -208,6 +210,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
         const response = await axios.post<TestResponse>(
           '/api/v1/settings/readarr/test',
           {
+            id,
             hostname,
             apiKey,
             port: Number(port),
@@ -260,6 +263,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
   useEffect(() => {
     if (readarr) {
       testConnection({
+        id: readarr.id,
         apiKey: readarr.apiKey,
         hostname: readarr.hostname,
         port: readarr.port,
@@ -377,6 +381,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
             onSecondary={async () => {
               if (values.apiKey && values.hostname && values.port) {
                 const response = await testConnection({
+                  id: readarr?.id,
                   apiKey: values.apiKey,
                   baseUrl: values.baseUrl,
                   hostname: values.hostname,
@@ -440,6 +445,7 @@ const ReadarrModal = ({ onClose, readarr, onSave }: ReadarrModalProps) => {
                         const response = await axios.post<DiagnosticResponse>(
                           '/api/v1/settings/readarr/diagnose',
                           {
+                            id: readarr?.id,
                             hostname: values.hostname,
                             apiKey: values.apiKey,
                             port: Number(values.port),

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1280,6 +1280,7 @@
   "components.Settings.ReadarrModal.testFirstMetadataProfiles": "Test connection to load metadata profiles",
   "components.Settings.ReadarrModal.testFirstQualityProfiles": "Test connection to load quality profiles",
   "components.Settings.ReadarrModal.testFirstRootFolders": "Test connection to load root folders",
+  "components.Settings.ReadarrModal.toastReadarrSaveFailure": "Failed to save the Bookshelf server.",
   "components.Settings.ReadarrModal.toastReadarrTestFailure": "Failed to connect to Bookshelf.",
   "components.Settings.ReadarrModal.toastReadarrTestSuccess": "Bookshelf connection established successfully!",
   "components.Settings.ReadarrModal.validationApiKeyRequired": "You must provide an API key",


### PR DESCRIPTION
## Description

The Bookshelf add form required fields that are only available after testing the connection, so a new server could fail before the form had enough information to populate those fields. The test action also read the previous React state when applying the discovered URL base.

This change validates connection-only settings for the test and diagnostic endpoints, allows connection testing before profiles and folders are selected, and uses the returned response when updating the URL base. It also gives new form fields stable empty defaults, handles save failures with an error toast, avoids requesting tags during the initial connection test, documents the connection-test request and response in the API schema, and adds coverage for incomplete add-form connection tests.

**AI Disclosure:** Codex was used to inspect and validate the implementation, run the combined tests and build, and draft this PR. The contributor requested submission after the combined build was deployed to their Kubernetes environment.

## How Has This Been Tested?

- `pnpm test server/routes/service.test.ts`
- ESLint on the changed Bookshelf/Servarr server and client files
- `pnpm typecheck`
- Full suite: 627 tests passed; one unrelated movie-discovery test hit a transient HTTP parser error and passed when rerun alone
- Successful production Docker build from the combined `develop` branch
- The combined image was deployed by digest and reached Kubernetes readiness with zero restarts

## Screenshots / Logs (if applicable)

Not included. The change is covered by route tests and form validation/type checking.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are required for this bug fix.
- [x] All new and existing tests passed. One unrelated full-suite transport failure passed on isolated rerun.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` — the new English save-error message was extracted.
- [x] Database migration (if required) — no database migration is required.
