### PR TITLE
feat(discover): cache homepage rows and revalidate state

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,20 +1,49 @@
 /* eslint-disable no-undef */
-// Incrementing OFFLINE_VERSION will kick off the install event and force
-// previously cached resources to be updated from the network.
-// This variable is intentionally declared and unused.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const OFFLINE_VERSION = 7;
-const CACHE_NAME = 'offline';
-const RUNTIME_CACHE_NAME = 'runtime-v3';
-const RUNTIME_CACHE_MAX_ENTRIES = 400;
+// Cache names change only when their stored data becomes incompatible. Normal
+// application builds keep compatible runtime data available for offline use.
+const OFFLINE_CACHE_NAME = 'seerrng-offline-v1';
+const DATA_CACHE_SCHEMA = 1;
+const DATA_CACHE_NAME = `seerrng-data-v${DATA_CACHE_SCHEMA}`;
+const STATIC_CACHE_SCHEMA = 1;
+const STATIC_CACHE_NAME = `seerrng-static-v${STATIC_CACHE_SCHEMA}`;
+const CLIENT_CACHE_SCHEMA = 1;
+const CLIENT_CACHE_NAME = `seerrng-client-v${CLIENT_CACHE_SCHEMA}`;
+const MANAGED_CACHE_PREFIXES = [
+  'seerrng-offline-',
+  'seerrng-data-',
+  'seerrng-static-',
+  'seerrng-client-',
+  // Cache names used before schema-based cache lifecycle management.
+  'runtime-',
+  'offline-',
+];
+const LEGACY_CACHE_NAMES = ['offline'];
+const DATA_CACHE_MAX_ENTRIES = 300;
+const STATIC_CACHE_MAX_ENTRIES = 200;
+const DATA_CACHE_FRESH_MS = 15 * 60 * 1000;
+const DATA_CACHE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const STATIC_CACHE_FRESH_MS = 24 * 60 * 60 * 1000;
+const STATIC_CACHE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const CACHE_TIMESTAMP_HEADER = 'x-seerrng-cache-time';
+const USER_CACHE_KEY_PARAM = '__seerrng_cache_user';
+const CLIENT_PARTITION_RETENTION_MS = DATA_CACHE_RETENTION_MS;
+const EXPIRATION_CLEANUP_INTERVAL_MS = 15 * 60 * 1000;
 // Customize this with a different URL if needed.
 const OFFLINE_URL = '/offline.html';
 
+// A service worker serves every signed-in user of a browser profile. Cache API
+// matching does not partition entries by cookies, so clients explicitly tell
+// the worker which user owns each authenticated response.
+const clientUserIds = new Map();
+const lastExpirationCleanup = new Map();
+
 const CACHEABLE_API_PATHS = [
-  /^\/api\/v1\/settings\/public$/,
   /^\/api\/v1\/settings\/discover$/,
   /^\/api\/v1\/discover(?:\/|$)/,
   /^\/api\/v1\/search(?:\/|$)/,
+  /^\/api\/v1\/media$/,
+  /^\/api\/v1\/request$/,
+  /^\/api\/v1\/request\/count$/,
   /^\/api\/v1\/movie\/\d+/,
   /^\/api\/v1\/tv\/\d+/,
   /^\/api\/v1\/collection\/\d+/,
@@ -24,6 +53,8 @@ const CACHEABLE_API_PATHS = [
   /^\/api\/v1\/author\/[^/]+/,
   /^\/api\/v1\/artist\/[^/]+/,
 ];
+
+const CACHEABLE_PUBLIC_API_PATHS = [/^\/api\/v1\/settings\/public$/];
 
 const CACHEABLE_STATIC_PATHS = [
   /^\/imageproxy\//,
@@ -35,24 +66,36 @@ const CACHEABLE_STATIC_PATHS = [
   /\.(aac|avif|css|flac|gif|ico|jpg|jpeg|js|m4a|map|mjs|mp3|mp4|oga|ogg|ogv|opus|otf|png|svg|ttf|wasm|wav|webm|webp|woff|woff2|json|txt|vtt|xml)$/i,
 ];
 
-const isRuntimeCacheableRequest = (request) => {
+const getRuntimeCacheType = (request) => {
   if (request.method !== 'GET') {
-    return false;
+    return undefined;
   }
 
   const url = new URL(request.url);
 
   if (url.origin !== self.location.origin) {
-    return false;
+    return undefined;
   }
 
   if (url.pathname.startsWith('/_next/')) {
-    return false;
+    return undefined;
   }
 
-  return [...CACHEABLE_API_PATHS, ...CACHEABLE_STATIC_PATHS].some((pattern) =>
-    pattern.test(url.pathname)
-  );
+  if (
+    CACHEABLE_PUBLIC_API_PATHS.some((pattern) => pattern.test(url.pathname))
+  ) {
+    return 'public-data';
+  }
+
+  if (CACHEABLE_API_PATHS.some((pattern) => pattern.test(url.pathname))) {
+    return 'user-data';
+  }
+
+  if (CACHEABLE_STATIC_PATHS.some((pattern) => pattern.test(url.pathname))) {
+    return 'static';
+  }
+
+  return undefined;
 };
 
 const isRuntimeCacheableResponse = (response) =>
@@ -61,61 +104,245 @@ const isRuntimeCacheableResponse = (response) =>
   response.status === 200 &&
   (response.type === 'basic' || response.type === 'default');
 
-const trimRuntimeCache = async (cache) => {
-  const keys = await cache.keys();
+const getCachedAt = (response) => {
+  const cachedAt = Number(response?.headers.get(CACHE_TIMESTAMP_HEADER));
+  return Number.isFinite(cachedAt) ? cachedAt : 0;
+};
 
-  if (keys.length <= RUNTIME_CACHE_MAX_ENTRIES) {
+const isFresh = (response, maxAgeMs) =>
+  Date.now() - getCachedAt(response) <= maxAgeMs;
+
+const addCacheTimestamp = (response) => {
+  const headers = new Headers(response.headers);
+  headers.set(CACHE_TIMESTAMP_HEADER, String(Date.now()));
+
+  return new Response(response.clone().body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const trimRuntimeCache = async (
+  cache,
+  maxEntries,
+  retentionMs,
+  cacheName,
+  forceExpiration = false
+) => {
+  const keys = await cache.keys();
+  const shouldCleanExpiration =
+    forceExpiration ||
+    Date.now() - (lastExpirationCleanup.get(cacheName) ?? 0) >=
+      EXPIRATION_CLEANUP_INTERVAL_MS;
+  let expiredKeys = [];
+
+  if (shouldCleanExpiration) {
+    // Set this before awaiting cache reads so parallel homepage requests do not
+    // all launch the same full expiration scan.
+    lastExpirationCleanup.set(cacheName, Date.now());
+    const responses = await Promise.all(
+      keys.map((request) => cache.match(request))
+    );
+    expiredKeys = keys.filter((request, index) => {
+      const cachedAt = getCachedAt(responses[index]);
+      return cachedAt > 0 && Date.now() - cachedAt > retentionMs;
+    });
+  }
+
+  await Promise.all(expiredKeys.map((request) => cache.delete(request)));
+
+  const remainingKeys = keys.filter(
+    (request) => !expiredKeys.includes(request)
+  );
+
+  if (remainingKeys.length <= maxEntries) {
     return;
   }
 
   await Promise.all(
-    keys
-      .slice(0, keys.length - RUNTIME_CACHE_MAX_ENTRIES)
+    remainingKeys
+      .slice(0, remainingKeys.length - maxEntries)
       .map((request) => cache.delete(request))
   );
 };
 
-const cacheRuntimeResponse = async (request, response) => {
+const getClientPartitionRequest = (clientId) =>
+  new Request(
+    new URL(
+      `/__seerrng_service_worker/client/${encodeURIComponent(clientId)}`,
+      self.location.origin
+    )
+  );
+
+const setClientUserId = async (clientId, userId) => {
+  const cache = await caches.open(CLIENT_CACHE_NAME);
+  const partitionRequest = getClientPartitionRequest(clientId);
+
+  if (!userId) {
+    clientUserIds.delete(clientId);
+    await cache.delete(partitionRequest);
+    return;
+  }
+
+  clientUserIds.set(clientId, userId);
+  await cache.put(
+    partitionRequest,
+    new Response(JSON.stringify({ userId, cachedAt: Date.now() }), {
+      headers: { 'content-type': 'application/json' },
+    })
+  );
+};
+
+const trimClientPartitions = async (cache) => {
+  const keys = await cache.keys();
+  const partitions = await Promise.all(
+    keys.map(async (request) => {
+      try {
+        const response = await cache.match(request);
+        return response ? await response.json() : undefined;
+      } catch {
+        return undefined;
+      }
+    })
+  );
+
+  await Promise.all(
+    keys
+      .filter((request, index) => {
+        const cachedAt = Number(partitions[index]?.cachedAt);
+        return (
+          !Number.isFinite(cachedAt) ||
+          Date.now() - cachedAt > CLIENT_PARTITION_RETENTION_MS
+        );
+      })
+      .map((request) => cache.delete(request))
+  );
+};
+
+const getClientUserId = async (clientId) => {
+  const inMemoryUserId = clientUserIds.get(clientId);
+  if (inMemoryUserId) {
+    return inMemoryUserId;
+  }
+
+  if (!clientId) {
+    return undefined;
+  }
+
+  try {
+    const cache = await caches.open(CLIENT_CACHE_NAME);
+    const partitionRequest = getClientPartitionRequest(clientId);
+    const response = await cache.match(partitionRequest);
+    const partition = response ? await response.json() : undefined;
+
+    if (
+      Number.isSafeInteger(partition?.userId) &&
+      partition.userId > 0 &&
+      Date.now() - partition.cachedAt <= CLIENT_PARTITION_RETENTION_MS
+    ) {
+      clientUserIds.set(clientId, partition.userId);
+      return partition.userId;
+    }
+
+    await cache.delete(partitionRequest);
+  } catch {
+    // Missing client metadata means personalized requests use the network only.
+  }
+
+  return undefined;
+};
+
+const getUserCacheRequest = async (request, clientId) => {
+  const userId = await getClientUserId(clientId);
+
+  if (!userId) {
+    return undefined;
+  }
+
+  const cacheUrl = new URL(request.url);
+  cacheUrl.searchParams.set(USER_CACHE_KEY_PARAM, String(userId));
+  return new Request(cacheUrl, { method: 'GET' });
+};
+
+const getCacheConfig = (cacheType) =>
+  cacheType === 'static'
+    ? {
+        cacheName: STATIC_CACHE_NAME,
+        freshMs: STATIC_CACHE_FRESH_MS,
+        retentionMs: STATIC_CACHE_RETENTION_MS,
+        maxEntries: STATIC_CACHE_MAX_ENTRIES,
+      }
+    : {
+        cacheName: DATA_CACHE_NAME,
+        freshMs: DATA_CACHE_FRESH_MS,
+        retentionMs: DATA_CACHE_RETENTION_MS,
+        maxEntries: DATA_CACHE_MAX_ENTRIES,
+      };
+
+const cacheRuntimeResponse = async (cache, cacheRequest, response, config) => {
   if (!isRuntimeCacheableResponse(response)) {
     return;
   }
 
   try {
-    const cache = await caches.open(RUNTIME_CACHE_NAME);
-    await cache.put(request, response.clone());
-    await trimRuntimeCache(cache);
+    await cache.put(cacheRequest, addCacheTimestamp(response));
+    await trimRuntimeCache(
+      cache,
+      config.maxEntries,
+      config.retentionMs,
+      config.cacheName
+    );
   } catch {
     // Runtime caching is opportunistic and should never break the request.
   }
 };
 
-const staleWhileRevalidate = async (request) => {
-  const cache = await caches.open(RUNTIME_CACHE_NAME);
-  const cachedResponse = await cache.match(request);
+const staleWhileRevalidate = async (request, cacheRequest, cacheType) => {
+  const config = getCacheConfig(cacheType);
+  const cache = await caches.open(config.cacheName);
+  const cachedResponse = await cache.match(cacheRequest);
   const networkResponsePromise = fetch(request)
     .then(async (networkResponse) => {
-      await cacheRuntimeResponse(request, networkResponse);
+      await cacheRuntimeResponse(cache, cacheRequest, networkResponse, config);
       return networkResponse;
     })
     .catch(() => undefined);
 
-  if (cachedResponse) {
-    return cachedResponse;
-  }
+  const responsePromise =
+    cachedResponse && isFresh(cachedResponse, config.freshMs)
+      ? Promise.resolve(cachedResponse)
+      : networkResponsePromise.then((networkResponse) => {
+          if (networkResponse && networkResponse.status < 500) {
+            return networkResponse;
+          }
 
-  const networkResponse = await networkResponsePromise;
+          // An expired entry remains useful when the server is unreachable.
+          // Retention cleanup eventually removes randomized query URLs.
+          return cachedResponse ?? networkResponse ?? Response.error();
+        });
 
-  if (networkResponse) {
-    return networkResponse;
-  }
-
-  return fetch(request);
+  return { responsePromise, networkResponsePromise };
 };
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type !== 'SET_CACHE_USER' || !event.source?.id) {
+    return;
+  }
+
+  const candidateUserId = Number(event.data.userId);
+  const userId =
+    Number.isSafeInteger(candidateUserId) && candidateUserId > 0
+      ? candidateUserId
+      : undefined;
+
+  event.waitUntil(setClientUserId(event.source.id, userId));
+});
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
     (async () => {
-      const cache = await caches.open(CACHE_NAME);
+      const cache = await caches.open(OFFLINE_CACHE_NAME);
       // Setting {cache: 'reload'} in the new request will ensure that the
       // response isn't fulfilled from the HTTP cache; i.e., it will be from
       // the network.
@@ -136,11 +363,50 @@ self.addEventListener('activate', (event) => {
       }
 
       const cacheKeys = await caches.keys();
+      const activeCacheNames = [
+        OFFLINE_CACHE_NAME,
+        DATA_CACHE_NAME,
+        STATIC_CACHE_NAME,
+        CLIENT_CACHE_NAME,
+      ];
       await Promise.all(
         cacheKeys
-          .filter((key) => ![CACHE_NAME, RUNTIME_CACHE_NAME].includes(key))
+          .filter(
+            (key) =>
+              (LEGACY_CACHE_NAMES.includes(key) ||
+                MANAGED_CACHE_PREFIXES.some((prefix) =>
+                  key.startsWith(prefix)
+                )) &&
+              !activeCacheNames.includes(key)
+          )
           .map((key) => caches.delete(key))
       );
+
+      await Promise.all([
+        caches
+          .open(DATA_CACHE_NAME)
+          .then((cache) =>
+            trimRuntimeCache(
+              cache,
+              DATA_CACHE_MAX_ENTRIES,
+              DATA_CACHE_RETENTION_MS,
+              DATA_CACHE_NAME,
+              true
+            )
+          ),
+        caches
+          .open(STATIC_CACHE_NAME)
+          .then((cache) =>
+            trimRuntimeCache(
+              cache,
+              STATIC_CACHE_MAX_ENTRIES,
+              STATIC_CACHE_RETENTION_MS,
+              STATIC_CACHE_NAME,
+              true
+            )
+          ),
+        caches.open(CLIENT_CACHE_NAME).then(trimClientPartitions),
+      ]);
     })()
   );
 
@@ -149,8 +415,34 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-  if (isRuntimeCacheableRequest(event.request)) {
-    event.respondWith(staleWhileRevalidate(event.request));
+  const cacheType = getRuntimeCacheType(event.request);
+
+  if (cacheType) {
+    const strategyPromise = (async () => {
+      const cacheRequest =
+        cacheType === 'user-data'
+          ? await getUserCacheRequest(event.request, event.clientId)
+          : event.request;
+
+      if (!cacheRequest) {
+        const networkResponsePromise = fetch(event.request);
+        return {
+          responsePromise: networkResponsePromise,
+          networkResponsePromise,
+        };
+      }
+
+      return staleWhileRevalidate(event.request, cacheRequest, cacheType);
+    })();
+
+    event.respondWith(
+      strategyPromise.then((strategy) => strategy.responsePromise)
+    );
+    event.waitUntil(
+      strategyPromise
+        .then((strategy) => strategy.networkResponsePromise)
+        .catch(() => undefined)
+    );
     return;
   }
 
@@ -177,7 +469,7 @@ self.addEventListener('fetch', (event) => {
           // eslint-disable-next-line no-console
           console.log('Fetch failed; returning offline page instead.', error);
 
-          const cache = await caches.open(CACHE_NAME);
+          const cache = await caches.open(OFFLINE_CACHE_NAME);
           const cachedResponse = await cache.match(OFFLINE_URL);
           return cachedResponse;
         }

--- a/public/sw.js
+++ b/public/sw.js
@@ -20,7 +20,7 @@ const MANAGED_CACHE_PREFIXES = [
 const LEGACY_CACHE_NAMES = ['offline'];
 const DATA_CACHE_MAX_ENTRIES = 300;
 const STATIC_CACHE_MAX_ENTRIES = 200;
-const DATA_CACHE_FRESH_MS = 15 * 60 * 1000;
+const DATA_CACHE_FRESH_MS = 5 * 60 * 1000;
 const DATA_CACHE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const STATIC_CACHE_FRESH_MS = 24 * 60 * 60 * 1000;
 const STATIC_CACHE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
@@ -54,8 +54,6 @@ const CACHEABLE_API_PATHS = [
   /^\/api\/v1\/artist\/[^/]+/,
 ];
 
-const CACHEABLE_PUBLIC_API_PATHS = [/^\/api\/v1\/settings\/public$/];
-
 const CACHEABLE_STATIC_PATHS = [
   /^\/imageproxy\//,
   /^\/avatarproxy\//,
@@ -81,12 +79,6 @@ const getRuntimeCacheType = (request) => {
     return undefined;
   }
 
-  if (
-    CACHEABLE_PUBLIC_API_PATHS.some((pattern) => pattern.test(url.pathname))
-  ) {
-    return 'public-data';
-  }
-
   if (CACHEABLE_API_PATHS.some((pattern) => pattern.test(url.pathname))) {
     return 'user-data';
   }
@@ -109,8 +101,17 @@ const getCachedAt = (response) => {
   return Number.isFinite(cachedAt) ? cachedAt : 0;
 };
 
-const isFresh = (response, maxAgeMs) =>
-  Date.now() - getCachedAt(response) <= maxAgeMs;
+const isFresh = (response, maxAgeMs) => {
+  const discoverFreshnessSeconds = Number(
+    response?.headers.get('x-discover-freshness')
+  );
+  const effectiveMaxAge =
+    Number.isFinite(discoverFreshnessSeconds) && discoverFreshnessSeconds >= 0
+      ? discoverFreshnessSeconds * 1000
+      : maxAgeMs;
+
+  return Date.now() - getCachedAt(response) < effectiveMaxAge;
+};
 
 const addCacheTimestamp = (response) => {
   const headers = new Headers(response.headers);

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -2544,6 +2544,107 @@ components:
         - enabled
         - title
         - data
+    DiscoverHomeManifest:
+      type: object
+      required:
+        - version
+        - layoutRevision
+        - userStateRevision
+        - generatedAt
+        - freshness
+        - rows
+      properties:
+        version:
+          type: integer
+          enum: [1]
+        layoutRevision:
+          type: string
+        userStateRevision:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        freshness:
+          type: object
+          required:
+            - manifestMaxAgeSeconds
+            - rowMaxAgeSeconds
+            - stateMaxAgeSeconds
+          properties:
+            manifestMaxAgeSeconds:
+              type: integer
+            rowMaxAgeSeconds:
+              type: integer
+            stateMaxAgeSeconds:
+              type: integer
+        rows:
+          type: array
+          items:
+            type: object
+            required:
+              - key
+              - sliderId
+              - type
+              - descriptorRevision
+            properties:
+              key:
+                type: string
+              sliderId:
+                type: integer
+              type:
+                type: integer
+              title:
+                type: string
+              data:
+                type: string
+              endpoint:
+                type: string
+              descriptorRevision:
+                type: string
+                description: Tracks row configuration only; use the row response ETag and freshness policy for catalog content.
+    DiscoverHomeState:
+      type: object
+      required:
+        - revision
+        - generatedAt
+        - items
+      properties:
+        revision:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        items:
+          type: array
+          items:
+            type: object
+            required:
+              - key
+              - mediaType
+              - id
+              - media
+              - request
+              - watchlisted
+            properties:
+              key:
+                type: string
+              mediaType:
+                type: string
+                enum: [movie, tv, music, book]
+              id:
+                oneOf:
+                  - type: integer
+                  - type: string
+              media:
+                type: object
+                nullable: true
+                additionalProperties: true
+              request:
+                type: object
+                nullable: true
+                additionalProperties: true
+              watchlisted:
+                type: boolean
     WatchProviderRegion:
       type: object
       properties:
@@ -5972,6 +6073,73 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Company'
+  /discover/home/manifest:
+    get:
+      summary: Get the Discover homepage synchronization manifest
+      description: Returns stable layout and personalized-state revisions. Row descriptor revisions do not track upstream catalog content.
+      tags:
+        - discover
+      responses:
+        '200':
+          description: Discover homepage manifest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverHomeManifest'
+        '304':
+          description: Manifest revisions are unchanged
+  /discover/home/state:
+    post:
+      summary: Get personalized state for a bounded set of Discover items
+      tags:
+        - discover
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - items
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  maxItems: 100
+                  items:
+                    oneOf:
+                      - type: object
+                        additionalProperties: false
+                        required: [mediaType, id]
+                        properties:
+                          mediaType:
+                            type: string
+                            enum: [movie, tv]
+                          id:
+                            type: integer
+                            minimum: 1
+                            maximum: 1000000000
+                      - type: object
+                        additionalProperties: false
+                        required: [mediaType, id]
+                        properties:
+                          mediaType:
+                            type: string
+                            enum: [music, book]
+                          id:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+      responses:
+        '200':
+          description: Personalized media, request, and watchlist state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverHomeState'
+        '400':
+          description: Invalid item list
   /discover/movies:
     get:
       summary: Discover movies

--- a/server/interfaces/api/discoverHomeInterfaces.ts
+++ b/server/interfaces/api/discoverHomeInterfaces.ts
@@ -1,0 +1,54 @@
+import type {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+
+export interface DiscoverHomeRowDescriptor {
+  key: string;
+  sliderId: number;
+  type: number;
+  title?: string;
+  data?: string;
+  endpoint?: string;
+  /** Tracks descriptor changes only. Catalog content is revalidated by row ETags. */
+  descriptorRevision: string;
+}
+
+export interface DiscoverHomeManifest {
+  version: 1;
+  layoutRevision: string;
+  userStateRevision: string;
+  generatedAt: string;
+  freshness: {
+    manifestMaxAgeSeconds: number;
+    rowMaxAgeSeconds: number;
+    stateMaxAgeSeconds: number;
+  };
+  rows: DiscoverHomeRowDescriptor[];
+}
+
+export interface DiscoverHomeStateItem {
+  key: string;
+  mediaType: MediaType;
+  id: number | string;
+  media: {
+    id: number;
+    status: MediaStatus;
+    status4k: MediaStatus;
+    updatedAt: string;
+  } | null;
+  request: {
+    id: number;
+    status: MediaRequestStatus;
+    is4k: boolean;
+    updatedAt: string;
+  } | null;
+  watchlisted: boolean;
+}
+
+export interface DiscoverHomeStateResponse {
+  revision: string;
+  generatedAt: string;
+  items: DiscoverHomeStateItem[];
+}

--- a/server/middleware/apiResponseCache.test.ts
+++ b/server/middleware/apiResponseCache.test.ts
@@ -37,6 +37,17 @@ describe('apiResponseCache', () => {
     assert.equal(res.headers.vary, 'Cookie, Accept-Encoding');
   });
 
+  it('preserves body-derived conditional ETags for unchanged discover rows', async () => {
+    const app = createApp();
+    const first = await request(app).get('/discover/books');
+    const unchanged = await request(app)
+      .get('/discover/books')
+      .set('If-None-Match', first.headers.etag);
+
+    assert.ok(first.headers.etag);
+    assert.equal(unchanged.status, 304);
+  });
+
   it('uses a shorter private cache for media details', async () => {
     const res = await request(createApp()).get('/book/OL1W');
 

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -68,6 +68,7 @@ import { Router } from 'express';
 import { sortBy } from 'lodash';
 import { In } from 'typeorm';
 import { z } from 'zod';
+import discoverHomeRoutes from './discoverHome';
 
 export const createTmdbWithRegionLanguage = (user?: User): TheMovieDb => {
   const settings = getSettings();
@@ -106,6 +107,8 @@ const MAX_DISCOVER_QUERY_LENGTH = 256;
 const MAX_DISCOVER_FILTER_LENGTH = 512;
 const trendingMediaTypes = ['all', 'movie', 'tv'] as const;
 const trendingTimeWindows = ['day', 'week'] as const;
+
+discoverRoutes.use('/home', discoverHomeRoutes);
 
 const parseOptionalDiscoverString = (
   value: unknown,

--- a/server/routes/discoverHome.ts
+++ b/server/routes/discoverHome.ts
@@ -36,18 +36,17 @@ const hashRevision = (value: unknown): string =>
 
 const rowEndpoints: Partial<Record<number, string>> = {
   [DiscoverSliderType.RECENTLY_ADDED]:
-    '/api/v1/media?filter=available&sort=mediaAdded',
-  [DiscoverSliderType.RECENT_REQUESTS]: '/api/v1/request?sort=modified',
+    '/api/v1/media?filter=allavailable&take=20&sort=mediaAdded&mediaType=movie%2Ctv',
+  [DiscoverSliderType.RECENT_REQUESTS]:
+    '/api/v1/request?filter=all&take=10&sort=modified&skip=0',
   [DiscoverSliderType.PLEX_WATCHLIST]: '/api/v1/discover/watchlist',
   [DiscoverSliderType.TRENDING]: '/api/v1/discover/trending',
   [DiscoverSliderType.POPULAR_MOVIES]: '/api/v1/discover/movies',
-  [DiscoverSliderType.MOVIE_GENRES]: '/api/v1/genres/movie',
+  [DiscoverSliderType.MOVIE_GENRES]: '/api/v1/discover/genreslider/movie',
   [DiscoverSliderType.UPCOMING_MOVIES]: '/api/v1/discover/movies',
-  [DiscoverSliderType.STUDIOS]: '/api/v1/studios',
   [DiscoverSliderType.POPULAR_TV]: '/api/v1/discover/tv',
-  [DiscoverSliderType.TV_GENRES]: '/api/v1/genres/tv',
+  [DiscoverSliderType.TV_GENRES]: '/api/v1/discover/genreslider/tv',
   [DiscoverSliderType.UPCOMING_TV]: '/api/v1/discover/tv',
-  [DiscoverSliderType.NETWORKS]: '/api/v1/networks',
   [DiscoverSliderType.POPULAR_MUSIC]: '/api/v1/discover/music?sortBy=ranked',
   [DiscoverSliderType.POPULAR_BOOKS]: '/api/v1/discover/books?sortBy=ranked',
 };

--- a/server/routes/discoverHome.ts
+++ b/server/routes/discoverHome.ts
@@ -1,0 +1,365 @@
+import { DiscoverSliderType } from '@server/constants/discover';
+import { MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import DiscoverSlider from '@server/entity/DiscoverSlider';
+import Media from '@server/entity/Media';
+import MediaIdentifier, {
+  MediaIdentifierProvider,
+} from '@server/entity/MediaIdentifier';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import type { User } from '@server/entity/User';
+import { Watchlist } from '@server/entity/Watchlist';
+import type {
+  DiscoverHomeManifest,
+  DiscoverHomeRowDescriptor,
+  DiscoverHomeStateItem,
+  DiscoverHomeStateResponse,
+} from '@server/interfaces/api/discoverHomeInterfaces';
+import {
+  normalizeMusicBrainzId,
+  normalizeOpenLibraryWorkId,
+} from '@server/lib/externalIds';
+import { createHash } from 'crypto';
+import type { Response } from 'express';
+import { Router } from 'express';
+import { In } from 'typeorm';
+import { z } from 'zod';
+
+const discoverHomeRoutes = Router();
+const MAX_STATE_ITEMS = 100;
+const MANIFEST_MAX_AGE_SECONDS = 60;
+const ROW_MAX_AGE_SECONDS = 300;
+const STATE_MAX_AGE_SECONDS = 30;
+
+const hashRevision = (value: unknown): string =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex').slice(0, 24);
+
+const rowEndpoints: Partial<Record<number, string>> = {
+  [DiscoverSliderType.RECENTLY_ADDED]:
+    '/api/v1/media?filter=available&sort=mediaAdded',
+  [DiscoverSliderType.RECENT_REQUESTS]: '/api/v1/request?sort=modified',
+  [DiscoverSliderType.PLEX_WATCHLIST]: '/api/v1/discover/watchlist',
+  [DiscoverSliderType.TRENDING]: '/api/v1/discover/trending',
+  [DiscoverSliderType.POPULAR_MOVIES]: '/api/v1/discover/movies',
+  [DiscoverSliderType.MOVIE_GENRES]: '/api/v1/genres/movie',
+  [DiscoverSliderType.UPCOMING_MOVIES]: '/api/v1/discover/movies',
+  [DiscoverSliderType.STUDIOS]: '/api/v1/studios',
+  [DiscoverSliderType.POPULAR_TV]: '/api/v1/discover/tv',
+  [DiscoverSliderType.TV_GENRES]: '/api/v1/genres/tv',
+  [DiscoverSliderType.UPCOMING_TV]: '/api/v1/discover/tv',
+  [DiscoverSliderType.NETWORKS]: '/api/v1/networks',
+  [DiscoverSliderType.POPULAR_MUSIC]: '/api/v1/discover/music?sortBy=ranked',
+  [DiscoverSliderType.POPULAR_BOOKS]: '/api/v1/discover/books?sortBy=ranked',
+};
+
+const getRowDescriptor = (
+  slider: DiscoverSlider
+): DiscoverHomeRowDescriptor => {
+  const descriptor = {
+    key: `slider-${slider.id}`,
+    sliderId: slider.id,
+    type: slider.type,
+    title: slider.title,
+    data: slider.data,
+    endpoint: rowEndpoints[slider.type],
+  };
+
+  return { ...descriptor, descriptorRevision: hashRevision(descriptor) };
+};
+
+const getUserStateRevision = async (user: User): Promise<string> => {
+  const [requestState, watchlistState] = await Promise.all([
+    getRepository(MediaRequest)
+      .createQueryBuilder('request')
+      .leftJoin('request.media', 'media')
+      .select('COUNT(request.id)', 'count')
+      .addSelect('MAX(request.updatedAt)', 'requestUpdatedAt')
+      .addSelect('MAX(media.updatedAt)', 'mediaUpdatedAt')
+      .where('request.requestedBy = :userId', { userId: user.id })
+      .getRawOne(),
+    getRepository(Watchlist)
+      .createQueryBuilder('watchlist')
+      .leftJoin('watchlist.media', 'media')
+      .select('COUNT(watchlist.id)', 'count')
+      .addSelect('MAX(watchlist.updatedAt)', 'watchlistUpdatedAt')
+      .addSelect('MAX(media.updatedAt)', 'mediaUpdatedAt')
+      .where('watchlist.requestedBy = :userId', { userId: user.id })
+      .getRawOne(),
+  ]);
+
+  return hashRevision({
+    userId: user.id,
+    userUpdatedAt: user.updatedAt,
+    permissions: user.permissions,
+    locale: user.settings?.locale,
+    streamingRegion: user.settings?.streamingRegion,
+    originalLanguage: user.settings?.originalLanguage,
+    requestState,
+    watchlistState,
+  });
+};
+
+const setPrivateFreshnessHeaders = (res: Response, maxAgeSeconds: number) => {
+  res.setHeader('Cache-Control', 'private, no-cache, stale-if-error=300');
+  res.setHeader('Vary', 'Cookie, Accept-Encoding');
+  res.setHeader('X-Discover-Freshness', String(maxAgeSeconds));
+};
+
+const etagMatches = (header: string | undefined, etag: string): boolean =>
+  header
+    ?.split(',')
+    .map((value) => value.trim().replace(/^W\//, ''))
+    .some((value) => value === etag.replace(/^W\//, '') || value === '*') ??
+  false;
+
+discoverHomeRoutes.get('/manifest', async (req, res) => {
+  const sliders = await getRepository(DiscoverSlider).find({
+    where: { enabled: true },
+    order: { order: 'ASC' },
+  });
+  const rows = sliders.map(getRowDescriptor);
+  const layoutRevision = hashRevision(rows);
+  const userStateRevision = await getUserStateRevision(req.user!);
+  // generatedAt changes between equivalent manifests, so use a weak validator
+  // over the stable semantic revisions rather than claiming byte equality.
+  const etag = `W/"${hashRevision({ layoutRevision, userStateRevision })}"`;
+
+  setPrivateFreshnessHeaders(res, MANIFEST_MAX_AGE_SECONDS);
+  res.setHeader('ETag', etag);
+  if (etagMatches(req.header('If-None-Match'), etag)) {
+    return res.status(304).end();
+  }
+
+  const manifest: DiscoverHomeManifest = {
+    version: 1,
+    layoutRevision,
+    userStateRevision,
+    generatedAt: new Date().toISOString(),
+    freshness: {
+      manifestMaxAgeSeconds: MANIFEST_MAX_AGE_SECONDS,
+      rowMaxAgeSeconds: ROW_MAX_AGE_SECONDS,
+      stateMaxAgeSeconds: STATE_MAX_AGE_SECONDS,
+    },
+    rows,
+  };
+
+  return res.json(manifest);
+});
+
+const numericItemSchema = z
+  .object({
+    mediaType: z.enum([MediaType.MOVIE, MediaType.TV]),
+    id: z.number().int().positive().max(1_000_000_000),
+  })
+  .strict();
+const externalItemSchema = z
+  .object({
+    mediaType: z.enum([MediaType.MUSIC, MediaType.BOOK]),
+    id: z.string().trim().min(1).max(128),
+  })
+  .strict();
+const stateBodySchema = z
+  .object({
+    items: z
+      .array(z.union([numericItemSchema, externalItemSchema]))
+      .min(1)
+      .max(MAX_STATE_ITEMS),
+  })
+  .strict();
+
+type StateInput = z.infer<typeof stateBodySchema>['items'][number];
+
+const normalizeInput = (item: StateInput): StateInput => {
+  if (item.mediaType === MediaType.MUSIC) {
+    return { ...item, id: normalizeMusicBrainzId(item.id) };
+  }
+  if (item.mediaType === MediaType.BOOK) {
+    return { ...item, id: normalizeOpenLibraryWorkId(item.id) };
+  }
+  return item;
+};
+
+const itemKey = (item: StateInput) => `${item.mediaType}:${item.id}`;
+
+discoverHomeRoutes.post('/state', async (req, res) => {
+  const parsed = stateBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      status: 400,
+      message: 'Invalid Discover state item list.',
+    });
+  }
+
+  const inputs = [
+    ...new Map(
+      parsed.data.items.map(normalizeInput).map((item) => [itemKey(item), item])
+    ).values(),
+  ];
+  const tmdbInputs = inputs.filter(
+    (item): item is Extract<StateInput, { id: number }> =>
+      typeof item.id === 'number'
+  );
+  const musicIds = inputs
+    .filter((item) => item.mediaType === MediaType.MUSIC)
+    .map((item) => String(item.id));
+  const bookIds = inputs
+    .filter((item) => item.mediaType === MediaType.BOOK)
+    .map((item) => String(item.id));
+  const movieIds = tmdbInputs
+    .filter((item) => item.mediaType === MediaType.MOVIE)
+    .map((item) => item.id);
+  const tvIds = tmdbInputs
+    .filter((item) => item.mediaType === MediaType.TV)
+    .map((item) => item.id);
+  const watchlistWhere = [
+    ...(movieIds.length
+      ? [
+          {
+            requestedBy: { id: req.user!.id },
+            mediaType: MediaType.MOVIE,
+            tmdbId: In(movieIds),
+          },
+        ]
+      : []),
+    ...(tvIds.length
+      ? [
+          {
+            requestedBy: { id: req.user!.id },
+            mediaType: MediaType.TV,
+            tmdbId: In(tvIds),
+          },
+        ]
+      : []),
+    ...(musicIds.length
+      ? [
+          {
+            requestedBy: { id: req.user!.id },
+            mediaType: MediaType.MUSIC,
+            mbId: In(musicIds),
+          },
+        ]
+      : []),
+    ...(bookIds.length
+      ? [
+          {
+            requestedBy: { id: req.user!.id },
+            mediaType: MediaType.BOOK,
+            externalId: In(bookIds),
+          },
+        ]
+      : []),
+  ];
+
+  const mediaRepository = getRepository(Media);
+  const [tmdbMedia, musicMedia, bookIdentifiers, watchlists] =
+    await Promise.all([
+      tmdbInputs.length
+        ? mediaRepository.find({
+            where: { tmdbId: In(tmdbInputs.map((item) => item.id)) },
+          })
+        : [],
+      musicIds.length
+        ? mediaRepository.find({ where: { mbId: In(musicIds) } })
+        : [],
+      bookIds.length
+        ? getRepository(MediaIdentifier).find({
+            where: {
+              provider: MediaIdentifierProvider.OPENLIBRARY,
+              value: In(bookIds),
+            },
+            relations: { media: true },
+          })
+        : [],
+      getRepository(Watchlist).find({ where: watchlistWhere }),
+    ]);
+  const allMedia = [
+    ...tmdbMedia,
+    ...musicMedia,
+    ...bookIdentifiers.map((identifier) => identifier.media),
+  ];
+  const mediaByKey = new Map<string, Media>();
+  for (const media of allMedia) {
+    if (
+      media.mediaType === MediaType.MOVIE ||
+      media.mediaType === MediaType.TV
+    ) {
+      mediaByKey.set(`${media.mediaType}:${media.tmdbId}`, media);
+    } else if (media.mediaType === MediaType.MUSIC && media.mbId) {
+      mediaByKey.set(
+        `${media.mediaType}:${normalizeMusicBrainzId(media.mbId)}`,
+        media
+      );
+    }
+  }
+  for (const identifier of bookIdentifiers) {
+    mediaByKey.set(
+      `${MediaType.BOOK}:${normalizeOpenLibraryWorkId(identifier.value)}`,
+      identifier.media
+    );
+  }
+
+  const mediaIds = [...new Set(allMedia.map((media) => media.id))];
+  const requests = mediaIds.length
+    ? await getRepository(MediaRequest).find({
+        where: {
+          requestedBy: { id: req.user!.id },
+          media: { id: In(mediaIds) },
+        },
+        order: { updatedAt: 'DESC' },
+      })
+    : [];
+  const requestByMediaId = new Map<number, MediaRequest>();
+  for (const mediaRequest of requests) {
+    if (!requestByMediaId.has(mediaRequest.media.id)) {
+      requestByMediaId.set(mediaRequest.media.id, mediaRequest);
+    }
+  }
+  const watchlistKeys = new Set(
+    watchlists.map((item) =>
+      item.mediaType === MediaType.MUSIC
+        ? `${item.mediaType}:${normalizeMusicBrainzId(item.mbId ?? '')}`
+        : item.mediaType === MediaType.BOOK
+          ? `${item.mediaType}:${normalizeOpenLibraryWorkId(item.externalId ?? '')}`
+          : `${item.mediaType}:${item.tmdbId}`
+    )
+  );
+
+  const items: DiscoverHomeStateItem[] = inputs.map((input) => {
+    const key = itemKey(input);
+    const media = mediaByKey.get(key);
+    const mediaRequest = media ? requestByMediaId.get(media.id) : undefined;
+    return {
+      key,
+      mediaType: input.mediaType,
+      id: input.id,
+      media: media
+        ? {
+            id: media.id,
+            status: media.status,
+            status4k: media.status4k,
+            updatedAt: media.updatedAt.toISOString(),
+          }
+        : null,
+      request: mediaRequest
+        ? {
+            id: mediaRequest.id,
+            status: mediaRequest.status,
+            is4k: mediaRequest.is4k,
+            updatedAt: mediaRequest.updatedAt.toISOString(),
+          }
+        : null,
+      watchlisted: watchlistKeys.has(key),
+    };
+  });
+  const response: DiscoverHomeStateResponse = {
+    revision: hashRevision(items),
+    generatedAt: new Date().toISOString(),
+    items,
+  };
+
+  res.setHeader('Cache-Control', 'private, no-store');
+  res.setHeader('Vary', 'Cookie, Accept-Encoding');
+  return res.json(response);
+});
+
+export default discoverHomeRoutes;

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,6 +1,18 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
 
+import { DiscoverSliderType } from '@server/constants/discover';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import DiscoverSlider from '@server/entity/DiscoverSlider';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { Watchlist } from '@server/entity/Watchlist';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
 import type { Express } from 'express';
@@ -49,6 +61,10 @@ afterEach(() => {
 setupTestDb();
 
 async function login() {
+  return loginAs('admin@seerr.dev');
+}
+
+async function loginAs(email: string) {
   const settings = getSettings();
   const priorLocalLogin = settings.main.localLogin;
   settings.main.localLogin = true;
@@ -57,13 +73,158 @@ async function login() {
     const agent = request.agent(app);
     const res = await agent
       .post('/api/v1/auth/local')
-      .send({ email: 'admin@seerr.dev', password: 'test1234' });
+      .send({ email, password: 'test1234' });
     assert.strictEqual(res.status, 200);
     return agent;
   } finally {
     settings.main.localLogin = priorLocalLogin;
   }
 }
+
+describe('Discover homepage synchronization API', () => {
+  it('requires authentication for manifest and state endpoints', async () => {
+    const [manifest, state] = await Promise.all([
+      request(app).get('/api/v1/discover/home/manifest'),
+      request(app)
+        .post('/api/v1/discover/home/state')
+        .send({ items: [{ mediaType: MediaType.MOVIE, id: 1 }] }),
+    ]);
+
+    assert.strictEqual(manifest.status, 403);
+    assert.strictEqual(state.status, 403);
+  });
+
+  it('returns stable descriptor revisions and conditionally revalidates the manifest', async () => {
+    const slider = await getRepository(DiscoverSlider).save(
+      new DiscoverSlider({
+        type: DiscoverSliderType.TRENDING,
+        order: 0,
+        enabled: true,
+        isBuiltIn: true,
+      })
+    );
+    const agent = await login();
+    const first = await agent.get('/api/v1/discover/home/manifest');
+    const second = await agent.get('/api/v1/discover/home/manifest');
+    const unchanged = await agent
+      .get('/api/v1/discover/home/manifest')
+      .set('If-None-Match', first.headers.etag);
+    slider.title = 'Changed descriptor';
+    await getRepository(DiscoverSlider).save(slider);
+    const changed = await agent.get('/api/v1/discover/home/manifest');
+
+    assert.strictEqual(first.status, 200);
+    assert.strictEqual(first.body.layoutRevision, second.body.layoutRevision);
+    assert.strictEqual(
+      first.body.userStateRevision,
+      second.body.userStateRevision
+    );
+    assert.strictEqual(
+      first.body.rows[0].descriptorRevision,
+      second.body.rows[0].descriptorRevision
+    );
+    assert.strictEqual(first.body.rows[0].revision, undefined);
+    assert.strictEqual(first.body.freshness.rowMaxAgeSeconds, 300);
+    assert.match(first.headers['cache-control'], /private/);
+    assert.strictEqual(unchanged.status, 304);
+    assert.notStrictEqual(
+      first.body.layoutRevision,
+      changed.body.layoutRevision
+    );
+    assert.notStrictEqual(
+      first.body.rows[0].descriptorRevision,
+      changed.body.rows[0].descriptorRevision
+    );
+  });
+
+  it('rejects malformed and oversized personalized state item lists', async () => {
+    const agent = await login();
+    const malformed = await agent
+      .post('/api/v1/discover/home/state')
+      .send({ items: [{ mediaType: MediaType.MOVIE, id: '1' }] });
+    const oversized = await agent.post('/api/v1/discover/home/state').send({
+      items: Array.from({ length: 101 }, (_, index) => ({
+        mediaType: MediaType.MOVIE,
+        id: index + 1,
+      })),
+    });
+
+    assert.strictEqual(malformed.status, 400);
+    assert.strictEqual(oversized.status, 400);
+  });
+
+  it('isolates request and watchlist overlays by authenticated user', async () => {
+    const [admin, friend] = await Promise.all([
+      getRepository(User).findOneOrFail({
+        where: { email: 'admin@seerr.dev' },
+      }),
+      getRepository(User).findOneOrFail({
+        where: { email: 'friend@seerr.dev' },
+      }),
+    ]);
+    const media = await getRepository(Media).save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 4242,
+        status: MediaStatus.PENDING,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+    await getRepository(MediaRequest).save(
+      new MediaRequest({
+        media,
+        requestedBy: admin,
+        status: MediaRequestStatus.APPROVED,
+        type: MediaType.MOVIE,
+        is4k: false,
+      })
+    );
+    await getRepository(Watchlist).save(
+      new Watchlist({
+        media,
+        requestedBy: admin,
+        mediaType: MediaType.MOVIE,
+        tmdbId: 4242,
+        title: 'Private Movie',
+        ratingKey: '4242',
+      })
+    );
+
+    const [adminAgent, friendAgent] = await Promise.all([
+      loginAs(admin.email),
+      loginAs(friend.email),
+    ]);
+    const body = { items: [{ mediaType: MediaType.MOVIE, id: 4242 }] };
+    const [adminState, friendState] = await Promise.all([
+      adminAgent.post('/api/v1/discover/home/state').send(body),
+      friendAgent.post('/api/v1/discover/home/state').send(body),
+    ]);
+
+    assert.strictEqual(adminState.status, 200);
+    assert.strictEqual(
+      adminState.body.items[0].request.status,
+      MediaRequestStatus.APPROVED
+    );
+    assert.strictEqual(adminState.body.items[0].watchlisted, true);
+    assert.strictEqual(friendState.status, 200);
+    assert.strictEqual(
+      friendState.body.items[0].media.status,
+      MediaStatus.PROCESSING
+    );
+    assert.strictEqual(friendState.body.items[0].request, null);
+    assert.strictEqual(friendState.body.items[0].watchlisted, false);
+    assert.notStrictEqual(adminState.body.revision, friendState.body.revision);
+
+    const [adminManifest, friendManifest] = await Promise.all([
+      adminAgent.get('/api/v1/discover/home/manifest'),
+      friendAgent.get('/api/v1/discover/home/manifest'),
+    ]);
+    assert.notStrictEqual(
+      adminManifest.body.userStateRevision,
+      friendManifest.body.userStateRevision
+    );
+  });
+});
 
 describe('Top-level API route validation', () => {
   it('allows unauthenticated login backdrop requests', async () => {

--- a/src/components/Discover/MovieGenreSlider/index.tsx
+++ b/src/components/Discover/MovieGenreSlider/index.tsx
@@ -1,6 +1,7 @@
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import Slider from '@app/components/Slider';
+import useDiscoverRowSnapshot from '@app/hooks/useDiscoverRowSnapshot';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
@@ -8,7 +9,8 @@ import Link from 'next/link';
 import React from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
-import useSWR from 'swr';
+
+const MOVIE_GENRES_URL = '/api/v1/discover/genreslider/movie';
 
 const messages = defineMessages('components.Discover.MovieGenreSlider', {
   moviegenres: 'Movie Genres',
@@ -20,13 +22,11 @@ const MovieGenreSlider = () => {
     rootMargin: '450px 0px',
     triggerOnce: true,
   });
-  const { data, error } = useSWR<GenreSliderItem[]>(
-    inView ? `/api/v1/discover/genreslider/movie` : null,
-    {
-      refreshInterval: 0,
-      revalidateOnFocus: false,
-    }
-  );
+  const { data, error, isLoading } = useDiscoverRowSnapshot<GenreSliderItem[]>({
+    enabled: inView,
+    rowKey: 'movie-genres',
+    url: MOVIE_GENRES_URL,
+  });
 
   return (
     <div ref={ref}>
@@ -38,7 +38,7 @@ const MovieGenreSlider = () => {
       </div>
       <Slider
         sliderKey="movie-genres"
-        isLoading={inView && !data && !error}
+        isLoading={isLoading && !error}
         isEmpty={false}
         items={(data ?? []).map((genre, index) => (
           <GenreCard

--- a/src/components/Discover/NetworkSlider/index.tsx
+++ b/src/components/Discover/NetworkSlider/index.tsx
@@ -1,7 +1,6 @@
 import CompanyCard from '@app/components/CompanyCard';
 import Slider from '@app/components/Slider';
 import defineMessages from '@app/utils/defineMessages';
-import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
 
 const messages = defineMessages('components.Discover.NetworkSlider', {
@@ -151,13 +150,8 @@ const networks: Network[] = [
 
 const NetworkSlider = () => {
   const intl = useIntl();
-  const { ref, inView } = useInView({
-    rootMargin: '450px 0px',
-    triggerOnce: true,
-  });
-
   return (
-    <div ref={ref}>
+    <div>
       <div className="slider-header">
         <div className="slider-title">
           <span>{intl.formatMessage(messages.networks)}</span>
@@ -165,20 +159,16 @@ const NetworkSlider = () => {
       </div>
       <Slider
         sliderKey="networks"
-        isLoading={!inView}
+        isLoading={false}
         isEmpty={false}
-        items={
-          inView
-            ? networks.map((network, index) => (
-                <CompanyCard
-                  key={`network-${index}`}
-                  name={network.name}
-                  image={network.image}
-                  url={network.url}
-                />
-              ))
-            : []
-        }
+        items={networks.map((network, index) => (
+          <CompanyCard
+            key={`network-${index}`}
+            name={network.name}
+            image={network.image}
+            url={network.url}
+          />
+        ))}
         placeholder={<CompanyCardPlaceholder />}
         emptyMessage=""
       />

--- a/src/components/Discover/PlexWatchlistSlider/index.tsx
+++ b/src/components/Discover/PlexWatchlistSlider/index.tsx
@@ -35,8 +35,9 @@ const PlexWatchlistSlider = () => {
     totalPages: number;
     totalResults: number;
     results: WatchlistItem[];
-  }>({
-    enabled: inView,
+    }>({
+      enabled: inView,
+      personalized: true,
     rowKey: 'watchlist',
     url: WATCHLIST_URL,
   });

--- a/src/components/Discover/PlexWatchlistSlider/index.tsx
+++ b/src/components/Discover/PlexWatchlistSlider/index.tsx
@@ -1,6 +1,7 @@
 import Slider from '@app/components/Slider';
 import LibraryTitleCard from '@app/components/TitleCard/LibraryTitleCard';
 import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
+import useDiscoverRowSnapshot from '@app/hooks/useDiscoverRowSnapshot';
 import { useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
@@ -9,7 +10,8 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
-import useSWR from 'swr';
+
+const WATCHLIST_URL = '/api/v1/discover/watchlist';
 
 const messages = defineMessages('components.Discover.PlexWatchlistSlider', {
   plexwatchlist: 'Your Watchlist',
@@ -24,13 +26,19 @@ const PlexWatchlistSlider = () => {
     triggerOnce: true,
   });
 
-  const { data: watchlistItems, error: watchlistError } = useSWR<{
+  const {
+    data: watchlistItems,
+    error: watchlistError,
+    isLoading,
+  } = useDiscoverRowSnapshot<{
     page: number;
     totalPages: number;
     totalResults: number;
     results: WatchlistItem[];
-  }>(inView ? '/api/v1/discover/watchlist' : null, {
-    revalidateOnFocus: false,
+  }>({
+    enabled: inView,
+    rowKey: 'watchlist',
+    url: WATCHLIST_URL,
   });
 
   const watchlistCards = useMemo(
@@ -89,7 +97,7 @@ const PlexWatchlistSlider = () => {
       </div>
       <Slider
         sliderKey="watchlist"
-        isLoading={inView && !watchlistItems}
+        isLoading={isLoading}
         isEmpty={isWatchlistEmpty}
         emptyMessage={intl.formatMessage(messages.emptywatchlist)}
         items={watchlistCards}

--- a/src/components/Discover/RecentRequestsSlider/index.tsx
+++ b/src/components/Discover/RecentRequestsSlider/index.tsx
@@ -1,6 +1,7 @@
 import { sliderTitles } from '@app/components/Discover/constants';
 import RequestCard from '@app/components/RequestCard';
 import Slider from '@app/components/Slider';
+import useDiscoverRowSnapshot from '@app/hooks/useDiscoverRowSnapshot';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
 import {
@@ -11,7 +12,8 @@ import type { RequestResultsResponse } from '@server/interfaces/api/requestInter
 import Link from 'next/link';
 import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
-import useSWR from 'swr';
+
+const REQUESTS_URL = '/api/v1/request?filter=all&take=10&sort=modified&skip=0';
 
 const messages = defineMessages('components.Discover.RecentRequestsSlider', {
   unableToConnect:
@@ -25,13 +27,15 @@ const RecentRequestsSlider = () => {
     rootMargin: '450px 0px',
     triggerOnce: true,
   });
-  const { data: requests, error: requestError } =
-    useSWR<RequestResultsResponse>(
-      inView ? '/api/v1/request?filter=all&take=10&sort=modified&skip=0' : null,
-      {
-        revalidateOnFocus: false,
-      }
-    );
+  const {
+    data: requests,
+    error: requestError,
+    isLoading,
+  } = useDiscoverRowSnapshot<RequestResultsResponse>({
+    enabled: inView,
+    rowKey: 'recent-requests',
+    url: REQUESTS_URL,
+  });
 
   const hasServiceErrors =
     requests?.serviceErrors &&
@@ -69,7 +73,7 @@ const RecentRequestsSlider = () => {
 
       <Slider
         sliderKey="requests"
-        isLoading={inView && !requests}
+        isLoading={isLoading}
         isEmpty={!!requests && requests.results.length === 0 && !requestError}
         items={(requests?.results ?? []).map((request) => (
           <RequestCard

--- a/src/components/Discover/RecentRequestsSlider/index.tsx
+++ b/src/components/Discover/RecentRequestsSlider/index.tsx
@@ -33,6 +33,7 @@ const RecentRequestsSlider = () => {
     isLoading,
   } = useDiscoverRowSnapshot<RequestResultsResponse>({
     enabled: inView,
+    personalized: true,
     rowKey: 'recent-requests',
     url: REQUESTS_URL,
   });

--- a/src/components/Discover/RecentlyAddedSlider/index.tsx
+++ b/src/components/Discover/RecentlyAddedSlider/index.tsx
@@ -28,6 +28,7 @@ const RecentlyAddedSlider = () => {
     isLoading,
   } = useDiscoverRowSnapshot<MediaResultsResponse>({
     enabled: inView,
+    personalized: true,
     rowKey: 'recently-added',
     url: RECENTLY_ADDED_URL,
   });

--- a/src/components/Discover/RecentlyAddedSlider/index.tsx
+++ b/src/components/Discover/RecentlyAddedSlider/index.tsx
@@ -1,12 +1,15 @@
 import Slider from '@app/components/Slider';
 import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
+import useDiscoverRowSnapshot from '@app/hooks/useDiscoverRowSnapshot';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
 import type { MediaResultsResponse } from '@server/interfaces/api/mediaInterfaces';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
-import useSWR from 'swr';
+
+const RECENTLY_ADDED_URL =
+  '/api/v1/media?filter=allavailable&take=20&sort=mediaAdded&mediaType=movie%2Ctv';
 
 const messages = defineMessages('components.Discover.RecentlyAddedSlider', {
   recentlyAdded: 'Recently Added',
@@ -19,12 +22,15 @@ const RecentlyAddedSlider = () => {
     rootMargin: '450px 0px',
     triggerOnce: true,
   });
-  const { data: media, error: mediaError } = useSWR<MediaResultsResponse>(
-    inView
-      ? '/api/v1/media?filter=allavailable&take=20&sort=mediaAdded&mediaType=movie%2Ctv'
-      : null,
-    { revalidateOnFocus: false }
-  );
+  const {
+    data: media,
+    error: mediaError,
+    isLoading,
+  } = useDiscoverRowSnapshot<MediaResultsResponse>({
+    enabled: inView,
+    rowKey: 'recently-added',
+    url: RECENTLY_ADDED_URL,
+  });
 
   const recentlyAddedCards = useMemo(
     () =>
@@ -59,7 +65,7 @@ const RecentlyAddedSlider = () => {
       </div>
       <Slider
         sliderKey="media"
-        isLoading={inView && !media}
+        isLoading={isLoading}
         isEmpty={!!media && !recentlyAddedCards.length && !mediaError}
         items={recentlyAddedCards}
       />

--- a/src/components/Discover/StudioSlider/index.tsx
+++ b/src/components/Discover/StudioSlider/index.tsx
@@ -1,7 +1,6 @@
 import CompanyCard from '@app/components/CompanyCard';
 import Slider from '@app/components/Slider';
 import defineMessages from '@app/utils/defineMessages';
-import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
 
 const messages = defineMessages('components.Discover.StudioSlider', {
@@ -85,13 +84,8 @@ const studios: Studio[] = [
 
 const StudioSlider = () => {
   const intl = useIntl();
-  const { ref, inView } = useInView({
-    rootMargin: '450px 0px',
-    triggerOnce: true,
-  });
-
   return (
-    <div ref={ref}>
+    <div>
       <div className="slider-header">
         <div className="slider-title">
           <span>{intl.formatMessage(messages.studios)}</span>
@@ -99,20 +93,16 @@ const StudioSlider = () => {
       </div>
       <Slider
         sliderKey="studios"
-        isLoading={!inView}
+        isLoading={false}
         isEmpty={false}
-        items={
-          inView
-            ? studios.map((studio, index) => (
-                <CompanyCard
-                  key={`studio-${index}`}
-                  name={studio.name}
-                  image={studio.image}
-                  url={studio.url}
-                />
-              ))
-            : []
-        }
+        items={studios.map((studio, index) => (
+          <CompanyCard
+            key={`studio-${index}`}
+            name={studio.name}
+            image={studio.image}
+            url={studio.url}
+          />
+        ))}
         placeholder={<CompanyCardPlaceholder />}
         emptyMessage=""
       />

--- a/src/components/Discover/TvGenreSlider/index.tsx
+++ b/src/components/Discover/TvGenreSlider/index.tsx
@@ -1,6 +1,7 @@
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import Slider from '@app/components/Slider';
+import useDiscoverRowSnapshot from '@app/hooks/useDiscoverRowSnapshot';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
@@ -8,7 +9,8 @@ import Link from 'next/link';
 import React from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useIntl } from 'react-intl';
-import useSWR from 'swr';
+
+const TV_GENRES_URL = '/api/v1/discover/genreslider/tv';
 
 const messages = defineMessages('components.Discover.TvGenreSlider', {
   tvgenres: 'Series Genres',
@@ -20,13 +22,11 @@ const TvGenreSlider = () => {
     rootMargin: '450px 0px',
     triggerOnce: true,
   });
-  const { data, error } = useSWR<GenreSliderItem[]>(
-    inView ? `/api/v1/discover/genreslider/tv` : null,
-    {
-      refreshInterval: 0,
-      revalidateOnFocus: false,
-    }
-  );
+  const { data, error, isLoading } = useDiscoverRowSnapshot<GenreSliderItem[]>({
+    enabled: inView,
+    rowKey: 'tv-genres',
+    url: TV_GENRES_URL,
+  });
 
   return (
     <div ref={ref}>
@@ -38,7 +38,7 @@ const TvGenreSlider = () => {
       </div>
       <Slider
         sliderKey="tv-genres"
-        isLoading={inView && !data && !error}
+        isLoading={isLoading && !error}
         isEmpty={false}
         items={(data ?? []).map((genre, index) => (
           <GenreCard

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -4,6 +4,7 @@ import PersonCard from '@app/components/PersonCard';
 import Slider from '@app/components/Slider';
 import TitleCard from '@app/components/TitleCard';
 import useCardTextVisibility from '@app/hooks/useCardTextVisibility';
+import useDiscoverHomeManifest from '@app/hooks/useDiscoverHomeManifest';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import {
@@ -15,10 +16,15 @@ import {
   useDiscoverSnapshot,
 } from '@app/utils/discoverSnapshot';
 import {
+  applyDiscoverStateOverlay,
+  getDiscoverStateInputs,
+} from '@app/utils/discoverStateOverlay';
+import {
   ArrowPathIcon,
   ArrowRightCircleIcon,
 } from '@heroicons/react/24/outline';
 import { MediaStatus } from '@server/constants/media';
+import type { DiscoverHomeStateResponse } from '@server/interfaces/api/discoverHomeInterfaces';
 import { Permission } from '@server/lib/permissions';
 import type {
   AlbumResult,
@@ -31,7 +37,7 @@ import type {
 import { appendDiscoverQueryString } from '@server/utils/discoverQuery';
 import axios from 'axios';
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import useSWRInfinite from 'swr/infinite';
 
@@ -127,6 +133,8 @@ const MediaSlider = ({
   const { hydrated: snapshotHydrated, snapshot } = useDiscoverSnapshot<
     MixedResult[]
   >(snapshotKey, cacheContextKey);
+  const { manifest } = useDiscoverHomeManifest(cacheContextKey);
+  const appliedUserStateRevision = useRef<string | undefined>(undefined);
   const [seedOverride, setSeedOverride] = useState<{
     snapshotKey?: string;
     seed: string;
@@ -180,10 +188,70 @@ const MediaSlider = ({
   });
 
   useEffect(() => {
-    if (shouldLoad && snapshot && !isDiscoverSnapshotFresh(snapshot)) {
+    const layoutChanged =
+      !!manifest &&
+      snapshot?.metadata.layoutRevision !== manifest.layoutRevision;
+
+    if (
+      shouldLoad &&
+      snapshot &&
+      (!isDiscoverSnapshotFresh(snapshot) || layoutChanged)
+    ) {
       void revalidate();
     }
-  }, [revalidate, shouldLoad, snapshot]);
+  }, [manifest, revalidate, shouldLoad, snapshot]);
+
+  useEffect(() => {
+    if (
+      !data?.length ||
+      !manifest ||
+      !cacheContextKey ||
+      !snapshotKey ||
+      snapshot?.metadata.userStateRevision === manifest.userStateRevision ||
+      appliedUserStateRevision.current === manifest.userStateRevision
+    ) {
+      return;
+    }
+
+    const inputs = getDiscoverStateInputs(data);
+
+    if (!inputs.length) {
+      appliedUserStateRevision.current = manifest.userStateRevision;
+      return;
+    }
+
+    appliedUserStateRevision.current = manifest.userStateRevision;
+    void axios
+      .post<DiscoverHomeStateResponse>('/api/v1/discover/home/state', {
+        items: inputs,
+      })
+      .then(async (response) => {
+        const updatedData = applyDiscoverStateOverlay(data, response.data);
+        await revalidate(updatedData, false);
+        await setDiscoverSnapshot(
+          snapshotKey,
+          createDiscoverSnapshot(cacheContextKey, updatedData, {
+            freshAgeMs: manifest.freshness.rowMaxAgeSeconds * 1000,
+            seed: randomizeOrder ? shuffleSeed : undefined,
+            manifestVersion: manifest.version,
+            layoutRevision: manifest.layoutRevision,
+            userStateRevision: manifest.userStateRevision,
+          })
+        );
+      })
+      .catch(() => {
+        appliedUserStateRevision.current = undefined;
+      });
+  }, [
+    cacheContextKey,
+    data,
+    manifest,
+    randomizeOrder,
+    revalidate,
+    shuffleSeed,
+    snapshot?.metadata.userStateRevision,
+    snapshotKey,
+  ]);
 
   const refreshRandomizedOrder = useCallback(() => {
     if (!randomizeOrder) {
@@ -281,10 +349,14 @@ const MediaSlider = ({
       data?.length &&
       data !== fallbackData
     ) {
-      setDiscoverSnapshot(
+      void setDiscoverSnapshot(
         snapshotKey,
         createDiscoverSnapshot(cacheContextKey, data, {
+          freshAgeMs: (manifest?.freshness.rowMaxAgeSeconds ?? 300) * 1000,
           seed: randomizeOrder ? shuffleSeed : undefined,
+          manifestVersion: manifest?.version,
+          layoutRevision: manifest?.layoutRevision,
+          userStateRevision: manifest?.userStateRevision,
         })
       );
     }
@@ -292,6 +364,7 @@ const MediaSlider = ({
     cacheContextKey,
     data,
     fallbackData,
+    manifest,
     randomizeOrder,
     shuffleSeed,
     snapshotKey,

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -7,9 +7,13 @@ import useCardTextVisibility from '@app/hooks/useCardTextVisibility';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import {
-  setPersistentResponse,
-  usePersistentResponse,
-} from '@app/utils/swrCache';
+  buildDiscoverCacheContextKey,
+  buildDiscoverSnapshotKey,
+  createDiscoverSnapshot,
+  isDiscoverSnapshotFresh,
+  setDiscoverSnapshot,
+  useDiscoverSnapshot,
+} from '@app/utils/discoverSnapshot';
 import {
   ArrowPathIcon,
   ArrowRightCircleIcon,
@@ -25,6 +29,7 @@ import type {
   TvResult,
 } from '@server/models/Search';
 import { appendDiscoverQueryString } from '@server/utils/discoverQuery';
+import axios from 'axios';
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -85,16 +90,54 @@ const MediaSlider = ({
     rootMargin: '450px 0px',
     triggerOnce: true,
   });
-  const shouldLoad = isEditingSafe() || inView;
-  const [shuffleSeed, setShuffleSeed] = useState(() =>
+  const [initialShuffleSeed] = useState(() =>
     Math.random().toString(36).slice(2)
   );
-  const fallbackCacheKey = useMemo(
+  const cacheContextKey = useMemo(
     () =>
-      `discover-slider:${user?.id ?? 'anonymous'}:${sliderKey}:${url}:${extraParams ?? ''}`,
-    [extraParams, sliderKey, url, user?.id]
+      user
+        ? buildDiscoverCacheContextKey({
+            userId: user.id,
+            permissions: user.permissions,
+            discoverRegion:
+              user.settings?.discoverRegion ??
+              settings.currentSettings.discoverRegion,
+            streamingRegion:
+              user.settings?.streamingRegion ??
+              settings.currentSettings.streamingRegion,
+            originalLanguage:
+              user.settings?.originalLanguage ??
+              settings.currentSettings.originalLanguage,
+          })
+        : undefined,
+    [
+      settings.currentSettings.discoverRegion,
+      settings.currentSettings.originalLanguage,
+      settings.currentSettings.streamingRegion,
+      user,
+    ]
   );
-  const fallbackData = usePersistentResponse<MixedResult[]>(fallbackCacheKey);
+  const snapshotKey = useMemo(
+    () =>
+      cacheContextKey
+        ? buildDiscoverSnapshotKey(cacheContextKey, sliderKey, url, extraParams)
+        : undefined,
+    [cacheContextKey, extraParams, sliderKey, url]
+  );
+  const { hydrated: snapshotHydrated, snapshot } = useDiscoverSnapshot<
+    MixedResult[]
+  >(snapshotKey, cacheContextKey);
+  const [seedOverride, setSeedOverride] = useState<{
+    snapshotKey?: string;
+    seed: string;
+  }>();
+  const shuffleSeed =
+    (seedOverride?.snapshotKey === snapshotKey
+      ? seedOverride?.seed
+      : snapshot?.metadata.seed) ?? initialShuffleSeed;
+  const fallbackData = snapshot?.data;
+  const shouldLoad =
+    !!user && snapshotHydrated && (!!fallbackData || isEditingSafe() || inView);
   const getKey = useCallback(
     (pageIndex: number, previousPageData: MixedResult | null) => {
       if (!shouldLoad) {
@@ -105,15 +148,18 @@ const MediaSlider = ({
         return null;
       }
 
-      return `${url}?${appendDiscoverQueryString(
-        {
-          page: pageIndex + 1,
-          shuffleSeed: randomizeOrder ? shuffleSeed : undefined,
-        },
-        extraParams
-      )}`;
+      return [
+        `${url}?${appendDiscoverQueryString(
+          {
+            page: pageIndex + 1,
+            shuffleSeed: randomizeOrder ? shuffleSeed : undefined,
+          },
+          extraParams
+        )}`,
+        cacheContextKey,
+      ] as const;
     },
-    [extraParams, randomizeOrder, shouldLoad, shuffleSeed, url]
+    [cacheContextKey, extraParams, randomizeOrder, shouldLoad, shuffleSeed, url]
   );
 
   const {
@@ -124,17 +170,20 @@ const MediaSlider = ({
     mutate: revalidate,
   } = useSWRInfinite<MixedResult>(getKey, {
     initialSize: 1,
-    revalidateFirstPage: true,
+    revalidateFirstPage: false,
+    revalidateOnMount: !fallbackData,
     dedupingInterval: 30000,
+    fetcher: ([requestUrl]: [string, string]) =>
+      axios.get<MixedResult>(requestUrl).then((response) => response.data),
     revalidateOnFocus: false,
     fallbackData,
   });
 
   useEffect(() => {
-    if (fallbackData) {
+    if (shouldLoad && snapshot && !isDiscoverSnapshotFresh(snapshot)) {
       void revalidate();
     }
-  }, [fallbackData, revalidate]);
+  }, [revalidate, shouldLoad, snapshot]);
 
   const refreshRandomizedOrder = useCallback(() => {
     if (!randomizeOrder) {
@@ -142,10 +191,11 @@ const MediaSlider = ({
     }
 
     setSize(1);
-    setShuffleSeed(
-      `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-    );
-  }, [randomizeOrder, setSize]);
+    setSeedOverride({
+      snapshotKey,
+      seed: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+    });
+  }, [randomizeOrder, setSize, snapshotKey]);
 
   const titles = useMemo(() => {
     const filteredTitles: SliderTitle[] = [];
@@ -225,10 +275,27 @@ const MediaSlider = ({
   }, [setSize, shouldLoadMore]);
 
   useEffect(() => {
-    if (data?.length && renderableTitles.length) {
-      setPersistentResponse(fallbackCacheKey, data);
+    if (
+      cacheContextKey &&
+      snapshotKey &&
+      data?.length &&
+      data !== fallbackData
+    ) {
+      setDiscoverSnapshot(
+        snapshotKey,
+        createDiscoverSnapshot(cacheContextKey, data, {
+          seed: randomizeOrder ? shuffleSeed : undefined,
+        })
+      );
     }
-  }, [data, fallbackCacheKey, renderableTitles.length]);
+  }, [
+    cacheContextKey,
+    data,
+    fallbackData,
+    randomizeOrder,
+    shuffleSeed,
+    snapshotKey,
+  ]);
 
   useEffect(() => {
     if (onNewTitles) {
@@ -410,7 +477,7 @@ const MediaSlider = ({
       </div>
       <Slider
         sliderKey={sliderKey}
-        isLoading={!data && !error}
+        isLoading={snapshotHydrated && shouldLoad && !data && !error}
         isEmpty={!!data && hasReachedEnd && !renderableTitles.length}
         items={finalTitles}
       />

--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -8,7 +8,9 @@ import { useEffect, useMemo } from 'react';
 
 import {
   canRegisterServiceWorker,
+  postCacheUserToWorker,
   shouldVerifyPushSubscription,
+  syncRegistrationCacheUser,
 } from './registration';
 
 const ServiceWorkerSetup = () => {
@@ -28,6 +30,15 @@ const ServiceWorkerSetup = () => {
       return;
     }
 
+    const syncControllerCacheUser = () =>
+      postCacheUserToWorker(navigator.serviceWorker.controller, userId);
+
+    navigator.serviceWorker.addEventListener(
+      'controllerchange',
+      syncControllerCacheUser
+    );
+    syncControllerCacheUser();
+
     const registerServiceWorker = () => {
       navigator.serviceWorker
         .register(versionedAsset('/sw.js'))
@@ -36,6 +47,8 @@ const ServiceWorkerSetup = () => {
             '[SW] Registration successful, scope is:',
             registration.scope
           );
+
+          syncRegistrationCacheUser(registration, userId);
 
           const pushNotificationsEnabled =
             localStorage.getItem('pushNotificationsEnabled') === 'true';
@@ -94,12 +107,24 @@ const ServiceWorkerSetup = () => {
         timeout: 5000,
       });
 
-      return () => window.cancelIdleCallback(idleCallback);
+      return () => {
+        window.cancelIdleCallback(idleCallback);
+        navigator.serviceWorker.removeEventListener(
+          'controllerchange',
+          syncControllerCacheUser
+        );
+      };
     }
 
     const timeout = globalThis.setTimeout(registerServiceWorker, 2000);
 
-    return () => globalThis.clearTimeout(timeout);
+    return () => {
+      globalThis.clearTimeout(timeout);
+      navigator.serviceWorker.removeEventListener(
+        'controllerchange',
+        syncControllerCacheUser
+      );
+    };
   }, [pushSettings, userId]);
   return null;
 };

--- a/src/components/ServiceWorkerSetup/registration.test.ts
+++ b/src/components/ServiceWorkerSetup/registration.test.ts
@@ -3,7 +3,10 @@ import { describe, it } from 'node:test';
 
 import {
   canRegisterServiceWorker,
+  createCacheUserMessage,
+  postCacheUserToWorker,
   shouldVerifyPushSubscription,
+  syncRegistrationCacheUser,
 } from './registration';
 
 describe('canRegisterServiceWorker', () => {
@@ -48,5 +51,39 @@ describe('shouldVerifyPushSubscription', () => {
       }),
       false
     );
+  });
+});
+
+describe('service worker cache user partition', () => {
+  it('uses an explicit null partition when no user is authenticated', () => {
+    assert.deepEqual(createCacheUserMessage(undefined), {
+      type: 'SET_CACHE_USER',
+      userId: null,
+    });
+  });
+
+  it('posts the current user to each worker lifecycle state', () => {
+    const messages: unknown[] = [];
+    const worker = {
+      postMessage: (message: unknown) => messages.push(message),
+    } as Pick<ServiceWorker, 'postMessage'>;
+
+    syncRegistrationCacheUser(
+      {
+        active: worker as ServiceWorker,
+        waiting: worker as ServiceWorker,
+        installing: null,
+      },
+      42
+    );
+
+    assert.deepEqual(messages, [
+      { type: 'SET_CACHE_USER', userId: 42 },
+      { type: 'SET_CACHE_USER', userId: 42 },
+    ]);
+  });
+
+  it('does nothing when there is no controlling worker', () => {
+    assert.equal(postCacheUserToWorker(null, 42), undefined);
   });
 });

--- a/src/components/ServiceWorkerSetup/registration.ts
+++ b/src/components/ServiceWorkerSetup/registration.ts
@@ -9,3 +9,29 @@ export const shouldVerifyPushSubscription = ({
   pushNotificationsEnabled: boolean;
   userId: number | undefined;
 }) => Boolean(userId && pushNotificationsEnabled);
+
+export const createCacheUserMessage = (userId: number | undefined) => ({
+  type: 'SET_CACHE_USER' as const,
+  userId: userId ?? null,
+});
+
+export const postCacheUserToWorker = (
+  worker: Pick<ServiceWorker, 'postMessage'> | null | undefined,
+  userId: number | undefined
+) => worker?.postMessage(createCacheUserMessage(userId));
+
+export const syncRegistrationCacheUser = (
+  registration: Pick<
+    ServiceWorkerRegistration,
+    'active' | 'installing' | 'waiting'
+  >,
+  userId: number | undefined
+) => {
+  const workers = [
+    registration.active,
+    registration.waiting,
+    registration.installing,
+  ];
+
+  workers.forEach((worker) => postCacheUserToWorker(worker, userId));
+};

--- a/src/components/ServiceWorkerSetup/sw.test.ts
+++ b/src/components/ServiceWorkerSetup/sw.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { runInNewContext } from 'node:vm';
+
+type Listener = (event: Record<string, unknown>) => void;
+
+class MemoryCache {
+  private entries = new Map<string, Response>();
+
+  async delete(request: Request | string) {
+    return this.entries.delete(this.key(request));
+  }
+
+  async keys() {
+    return [...this.entries.keys()].map((url) => new Request(url));
+  }
+
+  async match(request: Request | string) {
+    return this.entries.get(this.key(request))?.clone();
+  }
+
+  async put(request: Request | string, response: Response) {
+    this.entries.set(this.key(request), response.clone());
+  }
+
+  private key(request: Request | string) {
+    return typeof request === 'string' ? request : request.url;
+  }
+}
+
+const createHarness = () => {
+  const listeners = new Map<string, Listener>();
+  const cacheStores = new Map<string, MemoryCache>();
+  const networkResponses: (Response | Error)[] = [];
+
+  const caches = {
+    delete: async (name: string) => cacheStores.delete(name),
+    keys: async () => [...cacheStores.keys()],
+    open: async (name: string) => {
+      const cache = cacheStores.get(name) ?? new MemoryCache();
+      cacheStores.set(name, cache);
+      return cache;
+    },
+  };
+
+  const self = {
+    addEventListener: (type: string, listener: Listener) =>
+      listeners.set(type, listener),
+    location: { origin: 'https://seerr.test' },
+    registration: { navigationPreload: { enable: async () => undefined } },
+    skipWaiting: () => undefined,
+  };
+
+  runInNewContext(
+    readFileSync(resolve(__dirname, '../../../public/sw.js'), 'utf8'),
+    {
+      caches,
+      clients: { claim: () => undefined, openWindow: () => undefined },
+      console,
+      encodeURIComponent,
+      fetch: async () => {
+        const nextResponse = networkResponses.shift();
+        if (nextResponse instanceof Error) {
+          throw nextResponse;
+        }
+        return nextResponse ?? new Response(null, { status: 503 });
+      },
+      Headers,
+      Map,
+      navigator: {},
+      Number,
+      Promise,
+      Request,
+      Response,
+      self,
+      URL,
+    }
+  );
+
+  const setUser = async (userId: number | null) => {
+    const lifetimes: Promise<unknown>[] = [];
+    listeners.get('message')?.({
+      data: { type: 'SET_CACHE_USER', userId },
+      source: { id: 'client-1' },
+      waitUntil: (promise: Promise<unknown>) => lifetimes.push(promise),
+    });
+    await Promise.all(lifetimes);
+  };
+
+  const activate = async () => {
+    const lifetimes: Promise<unknown>[] = [];
+    listeners.get('activate')?.({
+      waitUntil: (promise: Promise<unknown>) => lifetimes.push(promise),
+    });
+    await Promise.all(lifetimes);
+  };
+
+  const fetchRequest = async (request: Request) => {
+    let responsePromise: Promise<Response> | undefined;
+    const lifetimes: Promise<unknown>[] = [];
+    listeners.get('fetch')?.({
+      clientId: 'client-1',
+      preloadResponse: Promise.resolve(undefined),
+      request,
+      respondWith: (promise: Promise<Response>) => {
+        responsePromise = promise;
+      },
+      waitUntil: (promise: Promise<unknown>) => lifetimes.push(promise),
+    });
+
+    const response = responsePromise ? await responsePromise : undefined;
+    await Promise.all(lifetimes);
+    return response;
+  };
+
+  return {
+    activate,
+    cacheNames: () => [...cacheStores.keys()],
+    fetchRequest,
+    networkResponses,
+    seedCache: (name: string) => caches.open(name),
+    setUser,
+  };
+};
+
+describe('service worker runtime cache', () => {
+  it('preserves compatible and unrelated caches during activation', async () => {
+    const harness = createHarness();
+    await Promise.all([
+      harness.seedCache('seerrng-data-v1'),
+      harness.seedCache('runtime-v3'),
+      harness.seedCache('third-party-cache'),
+    ]);
+
+    await harness.activate();
+
+    assert.equal(harness.cacheNames().includes('seerrng-data-v1'), true);
+    assert.equal(harness.cacheNames().includes('runtime-v3'), false);
+    assert.equal(harness.cacheNames().includes('third-party-cache'), true);
+  });
+
+  it('never intercepts mutations', async () => {
+    const harness = createHarness();
+    const response = await harness.fetchRequest(
+      new Request('https://seerr.test/api/v1/request', { method: 'POST' })
+    );
+
+    assert.equal(response, undefined);
+  });
+
+  it('isolates personalized data and retains stale data on network failure', async () => {
+    const harness = createHarness();
+    const request = new Request(
+      'https://seerr.test/api/v1/media?filter=allavailable'
+    );
+
+    await harness.setUser(1);
+    harness.networkResponses.push(new Response('user-one'));
+    assert.equal(
+      await (await harness.fetchRequest(request))?.text(),
+      'user-one'
+    );
+
+    await harness.setUser(2);
+    harness.networkResponses.push(new Response('user-two'));
+    assert.equal(
+      await (await harness.fetchRequest(request))?.text(),
+      'user-two'
+    );
+
+    await harness.setUser(1);
+    harness.networkResponses.push(new Error('offline'));
+    assert.equal(
+      await (await harness.fetchRequest(request))?.text(),
+      'user-one'
+    );
+  });
+});

--- a/src/components/ServiceWorkerSetup/sw.test.ts
+++ b/src/components/ServiceWorkerSetup/sw.test.ts
@@ -150,6 +150,31 @@ describe('service worker runtime cache', () => {
     assert.equal(response, undefined);
   });
 
+  it('does not cache public settings with a no-store contract', async () => {
+    const harness = createHarness();
+    const response = await harness.fetchRequest(
+      new Request('https://seerr.test/api/v1/settings/public')
+    );
+
+    assert.equal(response, undefined);
+  });
+
+  it('honors Discover freshness headers before using cached data', async () => {
+    const harness = createHarness();
+    const request = new Request(
+      'https://seerr.test/api/v1/discover/home/manifest'
+    );
+
+    await harness.setUser(1);
+    harness.networkResponses.push(
+      new Response('first', { headers: { 'X-Discover-Freshness': '0' } })
+    );
+    assert.equal(await (await harness.fetchRequest(request))?.text(), 'first');
+
+    harness.networkResponses.push(new Response('second'));
+    assert.equal(await (await harness.fetchRequest(request))?.text(), 'second');
+  });
+
   it('isolates personalized data and retains stale data on network failure', async () => {
     const harness = createHarness();
     const request = new Request(

--- a/src/hooks/useDiscoverHomeManifest.test.ts
+++ b/src/hooks/useDiscoverHomeManifest.test.ts
@@ -1,0 +1,48 @@
+import type { DiscoverHomeManifest } from '@server/interfaces/api/discoverHomeInterfaces';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  isManifestCacheFresh,
+  readManifestCache,
+} from './useDiscoverHomeManifest';
+
+class MemoryStorage {
+  values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+}
+
+const manifest: DiscoverHomeManifest = {
+  version: 1,
+  layoutRevision: 'layout-1',
+  userStateRevision: 'state-1',
+  generatedAt: new Date(0).toISOString(),
+  freshness: {
+    manifestMaxAgeSeconds: 60,
+    rowMaxAgeSeconds: 300,
+    stateMaxAgeSeconds: 30,
+  },
+  rows: [],
+};
+
+describe('Discover home manifest cache', () => {
+  it('isolates compact manifest records by cache context', () => {
+    const storage = new MemoryStorage();
+    storage.values.set(
+      'seerr-discover-manifest-v1:user-1',
+      JSON.stringify({ contextKey: 'user-1', checkedAt: 1000, manifest })
+    );
+
+    assert.deepEqual(readManifestCache(storage, 'user-1')?.manifest, manifest);
+    assert.equal(readManifestCache(storage, 'user-2'), undefined);
+  });
+
+  it('uses server-provided manifest freshness', () => {
+    const record = { contextKey: 'user-1', checkedAt: 1000, manifest };
+
+    assert.equal(isManifestCacheFresh(record, 60_999), true);
+    assert.equal(isManifestCacheFresh(record, 61_000), false);
+  });
+});

--- a/src/hooks/useDiscoverHomeManifest.ts
+++ b/src/hooks/useDiscoverHomeManifest.ts
@@ -1,0 +1,126 @@
+import type { DiscoverHomeManifest } from '@server/interfaces/api/discoverHomeInterfaces';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import useSWR from 'swr';
+
+const MANIFEST_URL = '/api/v1/discover/home/manifest';
+const MANIFEST_CACHE_PREFIX = 'seerr-discover-manifest-v1:';
+
+interface ManifestCacheRecord {
+  contextKey: string;
+  checkedAt: number;
+  etag?: string;
+  manifest: DiscoverHomeManifest;
+}
+
+const getStorage = () => {
+  try {
+    return typeof window === 'undefined' ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+const getManifestCacheKey = (contextKey: string) =>
+  `${MANIFEST_CACHE_PREFIX}${encodeURIComponent(contextKey)}`;
+
+export const readManifestCache = (
+  storage: Pick<Storage, 'getItem'>,
+  contextKey: string
+): ManifestCacheRecord | undefined => {
+  try {
+    const rawRecord = storage.getItem(getManifestCacheKey(contextKey));
+    const record = rawRecord
+      ? (JSON.parse(rawRecord) as Partial<ManifestCacheRecord>)
+      : undefined;
+
+    return record?.contextKey === contextKey && record.manifest?.version === 1
+      ? (record as ManifestCacheRecord)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const isManifestCacheFresh = (
+  record: ManifestCacheRecord,
+  now = Date.now()
+) =>
+  record.checkedAt + record.manifest.freshness.manifestMaxAgeSeconds * 1000 >
+  now;
+
+const writeManifestCache = (
+  storage: Pick<Storage, 'setItem'>,
+  contextKey: string,
+  record: ManifestCacheRecord
+) => {
+  try {
+    storage.setItem(getManifestCacheKey(contextKey), JSON.stringify(record));
+  } catch {
+    // The manifest is only an optimization; SWR still retains the live value.
+  }
+};
+
+const useDiscoverHomeManifest = (contextKey: string | undefined) => {
+  const [cachedResponse, setCachedResponse] = useState<{
+    contextKey?: string;
+    record?: ManifestCacheRecord;
+  }>();
+
+  useEffect(() => {
+    const storage = getStorage();
+    setCachedResponse({
+      contextKey,
+      record:
+        storage && contextKey
+          ? readManifestCache(storage, contextKey)
+          : undefined,
+    });
+  }, [contextKey]);
+
+  const hydrated = cachedResponse?.contextKey === contextKey;
+  const cachedRecord = hydrated ? cachedResponse?.record : undefined;
+  const { data, error } = useSWR<DiscoverHomeManifest>(
+    hydrated && contextKey ? [MANIFEST_URL, contextKey] : null,
+    {
+      fallbackData: cachedRecord?.manifest,
+      fetcher: async () => {
+        const storage = getStorage();
+        const currentRecord =
+          storage && contextKey
+            ? readManifestCache(storage, contextKey)
+            : undefined;
+        const response = await axios.get<DiscoverHomeManifest>(MANIFEST_URL, {
+          headers: currentRecord?.etag
+            ? { 'If-None-Match': currentRecord.etag }
+            : undefined,
+          validateStatus: (status) => status === 200 || status === 304,
+        });
+        const record: ManifestCacheRecord = {
+          contextKey: contextKey!,
+          checkedAt: Date.now(),
+          etag: response.headers.etag ?? currentRecord?.etag,
+          manifest:
+            response.status === 304 && currentRecord
+              ? currentRecord.manifest
+              : response.data,
+        };
+
+        if (storage) {
+          writeManifestCache(storage, contextKey!, record);
+        }
+
+        return record.manifest;
+      },
+      revalidateOnFocus: false,
+      revalidateOnMount: !cachedRecord || !isManifestCacheFresh(cachedRecord),
+      refreshInterval: (latestManifest) =>
+        (latestManifest?.freshness.manifestMaxAgeSeconds ?? 60) * 1000,
+      refreshWhenHidden: false,
+    }
+  );
+
+  return { manifest: data, error };
+};
+
+export default useDiscoverHomeManifest;

--- a/src/hooks/useDiscoverRowSnapshot.ts
+++ b/src/hooks/useDiscoverRowSnapshot.ts
@@ -1,0 +1,104 @@
+import useSettings from '@app/hooks/useSettings';
+import { useUser } from '@app/hooks/useUser';
+import {
+  buildDiscoverCacheContextKey,
+  buildDiscoverSnapshotKey,
+  createDiscoverSnapshot,
+  isDiscoverSnapshotFresh,
+  setDiscoverSnapshot,
+  useDiscoverSnapshot,
+} from '@app/utils/discoverSnapshot';
+import axios from 'axios';
+import { useEffect, useMemo } from 'react';
+import useSWR from 'swr';
+
+interface DiscoverRowSnapshotOptions {
+  enabled: boolean;
+  rowKey: string;
+  url: string;
+}
+
+const useDiscoverRowSnapshot = <T>({
+  enabled,
+  rowKey,
+  url,
+}: DiscoverRowSnapshotOptions) => {
+  const settings = useSettings();
+  const { user } = useUser();
+  const contextKey = useMemo(
+    () =>
+      user
+        ? buildDiscoverCacheContextKey({
+            userId: user.id,
+            permissions: user.permissions,
+            discoverRegion:
+              user.settings?.discoverRegion ??
+              settings.currentSettings.discoverRegion,
+            streamingRegion:
+              user.settings?.streamingRegion ??
+              settings.currentSettings.streamingRegion,
+            originalLanguage:
+              user.settings?.originalLanguage ??
+              settings.currentSettings.originalLanguage,
+          })
+        : undefined,
+    [
+      settings.currentSettings.discoverRegion,
+      settings.currentSettings.originalLanguage,
+      settings.currentSettings.streamingRegion,
+      user,
+    ]
+  );
+  const snapshotKey = useMemo(
+    () =>
+      contextKey
+        ? buildDiscoverSnapshotKey(contextKey, rowKey, url)
+        : undefined,
+    [contextKey, rowKey, url]
+  );
+  const { hydrated, snapshot } = useDiscoverSnapshot<T>(
+    snapshotKey,
+    contextKey
+  );
+  const fallbackData = snapshot?.data;
+  const shouldLoad =
+    !!user && hydrated && (fallbackData !== undefined || enabled);
+  const { data, error, mutate } = useSWR<T>(
+    shouldLoad && contextKey ? [url, contextKey] : null,
+    {
+      fallbackData,
+      fetcher: ([requestUrl]: [string, string]) =>
+        axios.get<T>(requestUrl).then((response) => response.data),
+      revalidateOnFocus: false,
+      revalidateOnMount: fallbackData === undefined,
+    }
+  );
+
+  useEffect(() => {
+    if (shouldLoad && snapshot && !isDiscoverSnapshotFresh(snapshot)) {
+      void mutate();
+    }
+  }, [mutate, shouldLoad, snapshot]);
+
+  useEffect(() => {
+    if (
+      contextKey &&
+      snapshotKey &&
+      data !== undefined &&
+      data !== fallbackData
+    ) {
+      setDiscoverSnapshot(
+        snapshotKey,
+        createDiscoverSnapshot(contextKey, data)
+      );
+    }
+  }, [contextKey, data, fallbackData, snapshotKey]);
+
+  return {
+    data,
+    error,
+    isLoading: hydrated && shouldLoad && data === undefined && !error,
+  };
+};
+
+export default useDiscoverRowSnapshot;

--- a/src/hooks/useDiscoverRowSnapshot.ts
+++ b/src/hooks/useDiscoverRowSnapshot.ts
@@ -1,3 +1,4 @@
+import useDiscoverHomeManifest from '@app/hooks/useDiscoverHomeManifest';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import {
@@ -14,12 +15,14 @@ import useSWR from 'swr';
 
 interface DiscoverRowSnapshotOptions {
   enabled: boolean;
+  personalized?: boolean;
   rowKey: string;
   url: string;
 }
 
 const useDiscoverRowSnapshot = <T>({
   enabled,
+  personalized = false,
   rowKey,
   url,
 }: DiscoverRowSnapshotOptions) => {
@@ -60,6 +63,7 @@ const useDiscoverRowSnapshot = <T>({
     snapshotKey,
     contextKey
   );
+  const { manifest } = useDiscoverHomeManifest(contextKey);
   const fallbackData = snapshot?.data;
   const shouldLoad =
     !!user && hydrated && (fallbackData !== undefined || enabled);
@@ -75,10 +79,22 @@ const useDiscoverRowSnapshot = <T>({
   );
 
   useEffect(() => {
-    if (shouldLoad && snapshot && !isDiscoverSnapshotFresh(snapshot)) {
+    const layoutChanged =
+      !!manifest &&
+      snapshot?.metadata.layoutRevision !== manifest.layoutRevision;
+    const userStateChanged =
+      personalized &&
+      !!manifest &&
+      snapshot?.metadata.userStateRevision !== manifest.userStateRevision;
+
+    if (
+      shouldLoad &&
+      snapshot &&
+      (!isDiscoverSnapshotFresh(snapshot) || layoutChanged || userStateChanged)
+    ) {
       void mutate();
     }
-  }, [mutate, shouldLoad, snapshot]);
+  }, [manifest, mutate, personalized, shouldLoad, snapshot]);
 
   useEffect(() => {
     if (
@@ -87,12 +103,17 @@ const useDiscoverRowSnapshot = <T>({
       data !== undefined &&
       data !== fallbackData
     ) {
-      setDiscoverSnapshot(
+      void setDiscoverSnapshot(
         snapshotKey,
-        createDiscoverSnapshot(contextKey, data)
+        createDiscoverSnapshot(contextKey, data, {
+          freshAgeMs: (manifest?.freshness.rowMaxAgeSeconds ?? 300) * 1000,
+          manifestVersion: manifest?.version,
+          layoutRevision: manifest?.layoutRevision,
+          userStateRevision: manifest?.userStateRevision,
+        })
       );
     }
-  }, [contextKey, data, fallbackData, snapshotKey]);
+  }, [contextKey, data, fallbackData, manifest, snapshotKey]);
 
   return {
     data,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,65 +3,6 @@ import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 import type { JSX } from 'react';
 
-const clientBuildVersion = process.env.commitTag ?? 'local';
-
-const staleServiceWorkerCleanupScript = `
-(function () {
-  var buildVersion = ${JSON.stringify(clientBuildVersion)};
-  var versionKey = 'seerrng:client-build-version';
-  var reloadKey = 'seerrng:stale-sw-reload:' + buildVersion;
-
-  try {
-    if (!buildVersion || buildVersion === 'local') {
-      return;
-    }
-
-    var previousVersion = window.localStorage.getItem(versionKey);
-
-    if (previousVersion === buildVersion) {
-      return;
-    }
-
-    window.localStorage.setItem(versionKey, buildVersion);
-
-    if (window.sessionStorage.getItem(reloadKey) === 'done') {
-      return;
-    }
-
-    window.sessionStorage.setItem(reloadKey, 'done');
-
-    var clearRuntimeCaches = 'caches' in window
-      ? window.caches.keys().then(function (cacheNames) {
-          return Promise.all(cacheNames.map(function (cacheName) {
-            return /^runtime/.test(cacheName) || /^offline-/.test(cacheName)
-              ? window.caches.delete(cacheName)
-              : Promise.resolve(false);
-          }));
-        })
-      : Promise.resolve();
-
-    var unregisterWorkers = 'serviceWorker' in navigator
-      ? navigator.serviceWorker.getRegistrations().then(function (registrations) {
-          return Promise.all(registrations.map(function (registration) {
-            var worker = registration.active || registration.waiting || registration.installing;
-            var scriptUrl = worker && worker.scriptURL ? new URL(worker.scriptURL) : null;
-
-            return scriptUrl && scriptUrl.pathname === '/sw.js'
-              ? registration.unregister()
-              : Promise.resolve(false);
-          }));
-        })
-      : Promise.resolve();
-
-    Promise.all([clearRuntimeCaches, unregisterWorkers]).finally(function () {
-      window.location.reload();
-    });
-  } catch (error) {
-    window.localStorage.setItem(versionKey, buildVersion);
-  }
-})();
-`;
-
 class MyDocument extends Document {
   static async getInitialProps(
     ctx: DocumentContext
@@ -74,13 +15,7 @@ class MyDocument extends Document {
   render(): JSX.Element {
     return (
       <Html lang="en">
-        <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: staleServiceWorkerCleanupScript,
-            }}
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />

--- a/src/utils/discoverSnapshot.test.ts
+++ b/src/utils/discoverSnapshot.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  DISCOVER_SNAPSHOT_FRESH_AGE,
+  DISCOVER_SNAPSHOT_MAX_AGE,
+  buildDiscoverCacheContextKey,
+  buildDiscoverSnapshotKey,
+  createDiscoverSnapshot,
+  isDiscoverSnapshotFresh,
+  readDiscoverSnapshot,
+  writeDiscoverSnapshot,
+} from './discoverSnapshot';
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const context = {
+  userId: 12,
+  permissions: 32,
+  discoverRegion: 'US',
+  streamingRegion: 'US',
+  originalLanguage: 'en',
+};
+
+describe('discover snapshots', () => {
+  it('isolates cache keys by user and effective discover context', () => {
+    const firstContext = buildDiscoverCacheContextKey(context);
+    const otherUser = buildDiscoverCacheContextKey({
+      ...context,
+      userId: 13,
+    });
+    const otherRegion = buildDiscoverCacheContextKey({
+      ...context,
+      discoverRegion: 'CA',
+    });
+
+    assert.notEqual(firstContext, otherUser);
+    assert.notEqual(firstContext, otherRegion);
+    assert.notEqual(
+      buildDiscoverSnapshotKey(firstContext, 'popular', '/discover', 'a=b'),
+      buildDiscoverSnapshotKey(otherUser, 'popular', '/discover', 'a=b')
+    );
+  });
+
+  it('preserves data and the randomized seed for the snapshot lifetime', () => {
+    const storage = new MemoryStorage();
+    const contextKey = buildDiscoverCacheContextKey(context);
+    const key = buildDiscoverSnapshotKey(
+      contextKey,
+      'popular',
+      '/api/v1/discover/movies'
+    );
+    const snapshot = createDiscoverSnapshot(contextKey, [{ id: 1 }], {
+      now: 1_000,
+      seed: 'stable-seed',
+      manifestVersion: 'manifest-1',
+      layoutRevision: 'layout-2',
+      userStateRevision: 'state-3',
+    });
+
+    writeDiscoverSnapshot(storage, key, snapshot);
+
+    assert.deepEqual(
+      readDiscoverSnapshot<{ id: number }[]>(
+        storage,
+        key,
+        contextKey,
+        1_000 + DISCOVER_SNAPSHOT_MAX_AGE - 1
+      ),
+      snapshot
+    );
+    assert.equal(snapshot.metadata.seed, 'stable-seed');
+    assert.equal(snapshot.metadata.manifestVersion, 'manifest-1');
+  });
+
+  it('distinguishes fresh snapshots from stale fallbacks', () => {
+    const snapshot = createDiscoverSnapshot('context', [], { now: 10_000 });
+
+    assert.equal(
+      isDiscoverSnapshotFresh(
+        snapshot,
+        10_000 + DISCOVER_SNAPSHOT_FRESH_AGE - 1
+      ),
+      true
+    );
+    assert.equal(
+      isDiscoverSnapshotFresh(snapshot, 10_000 + DISCOVER_SNAPSHOT_FRESH_AGE),
+      false
+    );
+  });
+
+  it('rejects expired and mismatched-context snapshots', () => {
+    const storage = new MemoryStorage();
+    const snapshot = createDiscoverSnapshot('user-1', ['cached'], { now: 0 });
+
+    writeDiscoverSnapshot(storage, 'expired', snapshot);
+    assert.equal(
+      readDiscoverSnapshot(
+        storage,
+        'expired',
+        'user-1',
+        DISCOVER_SNAPSHOT_MAX_AGE
+      ),
+      undefined
+    );
+    assert.equal(storage.getItem('expired'), null);
+
+    writeDiscoverSnapshot(storage, 'wrong-user', snapshot);
+    assert.equal(
+      readDiscoverSnapshot(storage, 'wrong-user', 'user-2', 1),
+      undefined
+    );
+    assert.equal(storage.getItem('wrong-user'), null);
+  });
+});

--- a/src/utils/discoverSnapshot.test.ts
+++ b/src/utils/discoverSnapshot.test.ts
@@ -27,6 +27,22 @@ class MemoryStorage {
   }
 }
 
+class MemoryPayloadStore {
+  private values = new Map<string, unknown>();
+
+  async delete(key: string) {
+    this.values.delete(key);
+  }
+
+  async get<T>(key: string) {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async set<T>(key: string, value: T) {
+    this.values.set(key, value);
+  }
+}
+
 const context = {
   userId: 12,
   permissions: 32,
@@ -55,8 +71,9 @@ describe('discover snapshots', () => {
     );
   });
 
-  it('preserves data and the randomized seed for the snapshot lifetime', () => {
+  it('keeps large payloads out of localStorage and preserves snapshot metadata', async () => {
     const storage = new MemoryStorage();
+    const payloadStore = new MemoryPayloadStore();
     const contextKey = buildDiscoverCacheContextKey(context);
     const key = buildDiscoverSnapshotKey(
       contextKey,
@@ -66,24 +83,26 @@ describe('discover snapshots', () => {
     const snapshot = createDiscoverSnapshot(contextKey, [{ id: 1 }], {
       now: 1_000,
       seed: 'stable-seed',
-      manifestVersion: 'manifest-1',
+      manifestVersion: 1,
       layoutRevision: 'layout-2',
       userStateRevision: 'state-3',
     });
 
-    writeDiscoverSnapshot(storage, key, snapshot);
+    await writeDiscoverSnapshot(storage, payloadStore, key, snapshot);
 
     assert.deepEqual(
-      readDiscoverSnapshot<{ id: number }[]>(
+      await readDiscoverSnapshot<{ id: number }[]>(
         storage,
+        payloadStore,
         key,
         contextKey,
         1_000 + DISCOVER_SNAPSHOT_MAX_AGE - 1
       ),
       snapshot
     );
+    assert.equal(storage.getItem(key), null);
     assert.equal(snapshot.metadata.seed, 'stable-seed');
-    assert.equal(snapshot.metadata.manifestVersion, 'manifest-1');
+    assert.equal(snapshot.metadata.manifestVersion, 1);
   });
 
   it('distinguishes fresh snapshots from stale fallbacks', () => {
@@ -102,27 +121,77 @@ describe('discover snapshots', () => {
     );
   });
 
-  it('rejects expired and mismatched-context snapshots', () => {
+  it('migrates legacy localStorage payloads into the payload store', async () => {
     const storage = new MemoryStorage();
+    const payloadStore = new MemoryPayloadStore();
+    const contextKey = buildDiscoverCacheContextKey(context);
+    const key = buildDiscoverSnapshotKey(
+      contextKey,
+      'popular',
+      '/api/v1/discover/movies'
+    );
+    const legacyKey = key.replace(
+      'seerr-discover-snapshot-v2:',
+      'seerr-discover-snapshot-v1:'
+    );
+    storage.setItem(
+      legacyKey,
+      JSON.stringify({
+        metadata: {
+          schemaVersion: 1,
+          contextKey,
+          createdAt: 1_000,
+          freshUntil: 2_000,
+          expiresAt: 10_000,
+          seed: 'legacy-seed',
+        },
+        data: [{ id: 1 }],
+      })
+    );
+
+    const migrated = await readDiscoverSnapshot<{ id: number }[]>(
+      storage,
+      payloadStore,
+      key,
+      contextKey,
+      1_500
+    );
+
+    assert.deepEqual(migrated?.data, [{ id: 1 }]);
+    assert.equal(migrated?.metadata.seed, 'legacy-seed');
+    assert.equal(storage.getItem(legacyKey), null);
+    assert.deepEqual(await payloadStore.get(key), [{ id: 1 }]);
+  });
+
+  it('rejects expired and mismatched-context snapshots', async () => {
+    const storage = new MemoryStorage();
+    const payloadStore = new MemoryPayloadStore();
     const snapshot = createDiscoverSnapshot('user-1', ['cached'], { now: 0 });
 
-    writeDiscoverSnapshot(storage, 'expired', snapshot);
+    await writeDiscoverSnapshot(storage, payloadStore, 'expired', snapshot);
     assert.equal(
-      readDiscoverSnapshot(
+      await readDiscoverSnapshot(
         storage,
+        payloadStore,
         'expired',
         'user-1',
         DISCOVER_SNAPSHOT_MAX_AGE
       ),
       undefined
     );
-    assert.equal(storage.getItem('expired'), null);
+    assert.equal(await payloadStore.get('expired'), undefined);
 
-    writeDiscoverSnapshot(storage, 'wrong-user', snapshot);
+    await writeDiscoverSnapshot(storage, payloadStore, 'wrong-user', snapshot);
     assert.equal(
-      readDiscoverSnapshot(storage, 'wrong-user', 'user-2', 1),
+      await readDiscoverSnapshot(
+        storage,
+        payloadStore,
+        'wrong-user',
+        'user-2',
+        1
+      ),
       undefined
     );
-    assert.equal(storage.getItem('wrong-user'), null);
+    assert.equal(await payloadStore.get('wrong-user'), undefined);
   });
 });

--- a/src/utils/discoverSnapshot.ts
+++ b/src/utils/discoverSnapshot.ts
@@ -1,0 +1,210 @@
+import { useEffect, useState } from 'react';
+
+export const DISCOVER_SNAPSHOT_SCHEMA_VERSION = 1;
+export const DISCOVER_SNAPSHOT_FRESH_AGE = 1000 * 60 * 15;
+export const DISCOVER_SNAPSHOT_MAX_AGE = 1000 * 60 * 60 * 24;
+
+const DISCOVER_SNAPSHOT_PREFIX = 'seerr-discover-snapshot-v1:';
+
+export interface DiscoverCacheContext {
+  userId: number;
+  permissions: number;
+  discoverRegion: string;
+  streamingRegion: string;
+  originalLanguage: string;
+}
+
+export interface DiscoverSnapshotMetadata {
+  schemaVersion: typeof DISCOVER_SNAPSHOT_SCHEMA_VERSION;
+  contextKey: string;
+  createdAt: number;
+  freshUntil: number;
+  expiresAt: number;
+  seed?: string;
+  manifestVersion?: string;
+  layoutRevision?: string;
+  userStateRevision?: string;
+}
+
+export interface DiscoverSnapshot<T> {
+  metadata: DiscoverSnapshotMetadata;
+  data: T;
+}
+
+type StorageLike = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
+
+const getBrowserStorage = (): StorageLike | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+export const buildDiscoverCacheContextKey = (
+  context: DiscoverCacheContext
+): string =>
+  [
+    context.userId,
+    context.permissions,
+    context.discoverRegion,
+    context.streamingRegion,
+    context.originalLanguage,
+  ]
+    .map((value) => encodeURIComponent(String(value)))
+    .join(':');
+
+export const buildDiscoverSnapshotKey = (
+  contextKey: string,
+  rowKey: string,
+  url: string,
+  extraParams = ''
+): string =>
+  `${DISCOVER_SNAPSHOT_PREFIX}${encodeURIComponent(
+    contextKey
+  )}:${encodeURIComponent(rowKey)}:${encodeURIComponent(
+    url
+  )}:${encodeURIComponent(extraParams)}`;
+
+export const createDiscoverSnapshot = <T>(
+  contextKey: string,
+  data: T,
+  {
+    now = Date.now(),
+    seed,
+    manifestVersion,
+    layoutRevision,
+    userStateRevision,
+  }: Partial<
+    Pick<
+      DiscoverSnapshotMetadata,
+      'seed' | 'manifestVersion' | 'layoutRevision' | 'userStateRevision'
+    >
+  > & { now?: number } = {}
+): DiscoverSnapshot<T> => ({
+  metadata: {
+    schemaVersion: DISCOVER_SNAPSHOT_SCHEMA_VERSION,
+    contextKey,
+    createdAt: now,
+    freshUntil: now + DISCOVER_SNAPSHOT_FRESH_AGE,
+    expiresAt: now + DISCOVER_SNAPSHOT_MAX_AGE,
+    seed,
+    manifestVersion,
+    layoutRevision,
+    userStateRevision,
+  },
+  data,
+});
+
+const isDiscoverSnapshot = <T>(
+  value: unknown
+): value is DiscoverSnapshot<T> => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<DiscoverSnapshot<T>>;
+  const metadata = candidate.metadata;
+
+  return (
+    !!metadata &&
+    metadata.schemaVersion === DISCOVER_SNAPSHOT_SCHEMA_VERSION &&
+    typeof metadata.contextKey === 'string' &&
+    typeof metadata.createdAt === 'number' &&
+    typeof metadata.freshUntil === 'number' &&
+    typeof metadata.expiresAt === 'number' &&
+    'data' in candidate
+  );
+};
+
+export const readDiscoverSnapshot = <T>(
+  storage: StorageLike,
+  key: string,
+  contextKey: string,
+  now = Date.now()
+): DiscoverSnapshot<T> | undefined => {
+  try {
+    const rawSnapshot = storage.getItem(key);
+
+    if (!rawSnapshot) {
+      return undefined;
+    }
+
+    const snapshot: unknown = JSON.parse(rawSnapshot);
+
+    if (
+      !isDiscoverSnapshot<T>(snapshot) ||
+      snapshot.metadata.contextKey !== contextKey ||
+      snapshot.metadata.expiresAt <= now
+    ) {
+      storage.removeItem(key);
+      return undefined;
+    }
+
+    return snapshot;
+  } catch {
+    storage.removeItem(key);
+    return undefined;
+  }
+};
+
+export const writeDiscoverSnapshot = <T>(
+  storage: StorageLike,
+  key: string,
+  snapshot: DiscoverSnapshot<T>
+) => {
+  try {
+    storage.setItem(key, JSON.stringify(snapshot));
+  } catch {
+    storage.removeItem(key);
+  }
+};
+
+export const isDiscoverSnapshotFresh = (
+  snapshot: DiscoverSnapshot<unknown>,
+  now = Date.now()
+): boolean => snapshot.metadata.freshUntil > now;
+
+export const setDiscoverSnapshot = <T>(
+  key: string,
+  snapshot: DiscoverSnapshot<T>
+) => {
+  const storage = getBrowserStorage();
+
+  if (storage) {
+    writeDiscoverSnapshot(storage, key, snapshot);
+  }
+};
+
+export const useDiscoverSnapshot = <T>(
+  key: string | undefined,
+  contextKey: string | undefined
+): { hydrated: boolean; snapshot?: DiscoverSnapshot<T> } => {
+  const [response, setResponse] = useState<{
+    key?: string;
+    snapshot?: DiscoverSnapshot<T>;
+  }>();
+
+  useEffect(() => {
+    const storage = getBrowserStorage();
+
+    setResponse({
+      key,
+      snapshot:
+        storage && key && contextKey
+          ? readDiscoverSnapshot<T>(storage, key, contextKey)
+          : undefined,
+    });
+  }, [contextKey, key]);
+
+  const hydrated = response?.key === key;
+
+  return {
+    hydrated,
+    snapshot: hydrated ? response?.snapshot : undefined,
+  };
+};

--- a/src/utils/discoverSnapshot.ts
+++ b/src/utils/discoverSnapshot.ts
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react';
 
-export const DISCOVER_SNAPSHOT_SCHEMA_VERSION = 1;
-export const DISCOVER_SNAPSHOT_FRESH_AGE = 1000 * 60 * 15;
+export const DISCOVER_SNAPSHOT_SCHEMA_VERSION = 2;
+export const DISCOVER_SNAPSHOT_FRESH_AGE = 1000 * 60 * 5;
 export const DISCOVER_SNAPSHOT_MAX_AGE = 1000 * 60 * 60 * 24;
 
-const DISCOVER_SNAPSHOT_PREFIX = 'seerr-discover-snapshot-v1:';
+const DISCOVER_SNAPSHOT_PREFIX = 'seerr-discover-snapshot-v2:';
+const LEGACY_DISCOVER_SNAPSHOT_PREFIX = 'seerr-discover-snapshot-v1:';
+const DISCOVER_SNAPSHOT_METADATA_SUFFIX = ':metadata';
+const DISCOVER_DATABASE_NAME = 'seerr-discover-cache';
+const DISCOVER_DATABASE_STORE = 'snapshots';
 
 export interface DiscoverCacheContext {
   userId: number;
@@ -21,7 +25,7 @@ export interface DiscoverSnapshotMetadata {
   freshUntil: number;
   expiresAt: number;
   seed?: string;
-  manifestVersion?: string;
+  manifestVersion?: number;
   layoutRevision?: string;
   userStateRevision?: string;
 }
@@ -29,6 +33,12 @@ export interface DiscoverSnapshotMetadata {
 export interface DiscoverSnapshot<T> {
   metadata: DiscoverSnapshotMetadata;
   data: T;
+}
+
+export interface DiscoverPayloadStore {
+  delete(key: string): Promise<void>;
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T): Promise<void>;
 }
 
 type StorageLike = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
@@ -44,6 +54,58 @@ const getBrowserStorage = (): StorageLike | undefined => {
     return undefined;
   }
 };
+
+let databasePromise: Promise<IDBDatabase> | undefined;
+
+const getDatabase = (): Promise<IDBDatabase> => {
+  if (!databasePromise) {
+    databasePromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DISCOVER_DATABASE_NAME, 1);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+      request.onupgradeneeded = () => {
+        if (
+          !request.result.objectStoreNames.contains(DISCOVER_DATABASE_STORE)
+        ) {
+          request.result.createObjectStore(DISCOVER_DATABASE_STORE);
+        }
+      };
+    });
+  }
+
+  return databasePromise;
+};
+
+const runDatabaseRequest = async <T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> => {
+  const database = await getDatabase();
+
+  return new Promise((resolve, reject) => {
+    const request = operation(
+      database
+        .transaction(DISCOVER_DATABASE_STORE, mode)
+        .objectStore(DISCOVER_DATABASE_STORE)
+    );
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+};
+
+const browserPayloadStore: DiscoverPayloadStore = {
+  delete: async (key) => {
+    await runDatabaseRequest('readwrite', (store) => store.delete(key));
+  },
+  get: async <T>(key: string) =>
+    runDatabaseRequest<T | undefined>('readonly', (store) => store.get(key)),
+  set: async <T>(key: string, value: T) => {
+    await runDatabaseRequest('readwrite', (store) => store.put(value, key));
+  },
+};
+
+const getBrowserPayloadStore = (): DiscoverPayloadStore | undefined =>
+  typeof indexedDB === 'undefined' ? undefined : browserPayloadStore;
 
 export const buildDiscoverCacheContextKey = (
   context: DiscoverCacheContext
@@ -75,6 +137,7 @@ export const createDiscoverSnapshot = <T>(
   data: T,
   {
     now = Date.now(),
+    freshAgeMs = DISCOVER_SNAPSHOT_FRESH_AGE,
     seed,
     manifestVersion,
     layoutRevision,
@@ -84,13 +147,13 @@ export const createDiscoverSnapshot = <T>(
       DiscoverSnapshotMetadata,
       'seed' | 'manifestVersion' | 'layoutRevision' | 'userStateRevision'
     >
-  > & { now?: number } = {}
+  > & { now?: number; freshAgeMs?: number } = {}
 ): DiscoverSnapshot<T> => ({
   metadata: {
     schemaVersion: DISCOVER_SNAPSHOT_SCHEMA_VERSION,
     contextKey,
     createdAt: now,
-    freshUntil: now + DISCOVER_SNAPSHOT_FRESH_AGE,
+    freshUntil: now + freshAgeMs,
     expiresAt: now + DISCOVER_SNAPSHOT_MAX_AGE,
     seed,
     manifestVersion,
@@ -100,67 +163,127 @@ export const createDiscoverSnapshot = <T>(
   data,
 });
 
-const isDiscoverSnapshot = <T>(
+const isSnapshotMetadata = (
   value: unknown
-): value is DiscoverSnapshot<T> => {
+): value is DiscoverSnapshotMetadata => {
   if (!value || typeof value !== 'object') {
     return false;
   }
 
-  const candidate = value as Partial<DiscoverSnapshot<T>>;
-  const metadata = candidate.metadata;
+  const metadata = value as Partial<DiscoverSnapshotMetadata>;
 
   return (
-    !!metadata &&
     metadata.schemaVersion === DISCOVER_SNAPSHOT_SCHEMA_VERSION &&
     typeof metadata.contextKey === 'string' &&
     typeof metadata.createdAt === 'number' &&
     typeof metadata.freshUntil === 'number' &&
-    typeof metadata.expiresAt === 'number' &&
-    'data' in candidate
+    typeof metadata.expiresAt === 'number'
   );
 };
 
-export const readDiscoverSnapshot = <T>(
+const getMetadataKey = (key: string) =>
+  `${key}${DISCOVER_SNAPSHOT_METADATA_SUFFIX}`;
+
+export const readDiscoverSnapshot = async <T>(
   storage: StorageLike,
+  payloadStore: DiscoverPayloadStore,
   key: string,
   contextKey: string,
   now = Date.now()
-): DiscoverSnapshot<T> | undefined => {
+): Promise<DiscoverSnapshot<T> | undefined> => {
+  const metadataKey = getMetadataKey(key);
+
   try {
-    const rawSnapshot = storage.getItem(key);
+    const rawMetadata = storage.getItem(metadataKey);
+    const metadata: unknown = rawMetadata ? JSON.parse(rawMetadata) : undefined;
 
-    if (!rawSnapshot) {
-      return undefined;
+    if (!rawMetadata) {
+      const legacyKey = key.replace(
+        DISCOVER_SNAPSHOT_PREFIX,
+        LEGACY_DISCOVER_SNAPSHOT_PREFIX
+      );
+      const rawLegacySnapshot = storage.getItem(legacyKey);
+      const legacySnapshot = rawLegacySnapshot
+        ? (JSON.parse(rawLegacySnapshot) as {
+            metadata?: Omit<DiscoverSnapshotMetadata, 'schemaVersion'> & {
+              schemaVersion?: number;
+            };
+            data?: T;
+          })
+        : undefined;
+      const legacyMetadata = legacySnapshot?.metadata;
+
+      if (
+        legacyMetadata?.schemaVersion === 1 &&
+        legacyMetadata.contextKey === contextKey &&
+        typeof legacyMetadata.expiresAt === 'number' &&
+        legacyMetadata.expiresAt > now &&
+        legacySnapshot?.data !== undefined
+      ) {
+        const migratedSnapshot = createDiscoverSnapshot(
+          contextKey,
+          legacySnapshot.data,
+          {
+            now: legacyMetadata.createdAt,
+            freshAgeMs: Math.max(
+              0,
+              legacyMetadata.freshUntil - legacyMetadata.createdAt
+            ),
+            seed: legacyMetadata.seed,
+            layoutRevision: legacyMetadata.layoutRevision,
+            userStateRevision: legacyMetadata.userStateRevision,
+          }
+        );
+        migratedSnapshot.metadata.expiresAt = legacyMetadata.expiresAt;
+
+        await writeDiscoverSnapshot(
+          storage,
+          payloadStore,
+          key,
+          migratedSnapshot
+        );
+        storage.removeItem(legacyKey);
+        return migratedSnapshot;
+      }
     }
-
-    const snapshot: unknown = JSON.parse(rawSnapshot);
 
     if (
-      !isDiscoverSnapshot<T>(snapshot) ||
-      snapshot.metadata.contextKey !== contextKey ||
-      snapshot.metadata.expiresAt <= now
+      !isSnapshotMetadata(metadata) ||
+      metadata.contextKey !== contextKey ||
+      metadata.expiresAt <= now
     ) {
-      storage.removeItem(key);
+      storage.removeItem(metadataKey);
+      await payloadStore.delete(key);
       return undefined;
     }
 
-    return snapshot;
+    const data = await payloadStore.get<T>(key);
+
+    if (data === undefined) {
+      storage.removeItem(metadataKey);
+      return undefined;
+    }
+
+    return { metadata, data };
   } catch {
-    storage.removeItem(key);
+    storage.removeItem(metadataKey);
+    await payloadStore.delete(key).catch(() => undefined);
     return undefined;
   }
 };
 
-export const writeDiscoverSnapshot = <T>(
+export const writeDiscoverSnapshot = async <T>(
   storage: StorageLike,
+  payloadStore: DiscoverPayloadStore,
   key: string,
   snapshot: DiscoverSnapshot<T>
 ) => {
   try {
-    storage.setItem(key, JSON.stringify(snapshot));
+    await payloadStore.set(key, snapshot.data);
+    storage.setItem(getMetadataKey(key), JSON.stringify(snapshot.metadata));
   } catch {
-    storage.removeItem(key);
+    storage.removeItem(getMetadataKey(key));
+    await payloadStore.delete(key).catch(() => undefined);
   }
 };
 
@@ -169,14 +292,15 @@ export const isDiscoverSnapshotFresh = (
   now = Date.now()
 ): boolean => snapshot.metadata.freshUntil > now;
 
-export const setDiscoverSnapshot = <T>(
+export const setDiscoverSnapshot = async <T>(
   key: string,
   snapshot: DiscoverSnapshot<T>
 ) => {
   const storage = getBrowserStorage();
+  const payloadStore = getBrowserPayloadStore();
 
-  if (storage) {
-    writeDiscoverSnapshot(storage, key, snapshot);
+  if (storage && payloadStore) {
+    await writeDiscoverSnapshot(storage, payloadStore, key, snapshot);
   }
 };
 
@@ -191,14 +315,30 @@ export const useDiscoverSnapshot = <T>(
 
   useEffect(() => {
     const storage = getBrowserStorage();
+    const payloadStore = getBrowserPayloadStore();
+    let cancelled = false;
 
-    setResponse({
-      key,
-      snapshot:
-        storage && key && contextKey
-          ? readDiscoverSnapshot<T>(storage, key, contextKey)
-          : undefined,
-    });
+    const hydrate = async () => {
+      const snapshot =
+        storage && payloadStore && key && contextKey
+          ? await readDiscoverSnapshot<T>(
+              storage,
+              payloadStore,
+              key,
+              contextKey
+            )
+          : undefined;
+
+      if (!cancelled) {
+        setResponse({ key, snapshot });
+      }
+    };
+
+    void hydrate();
+
+    return () => {
+      cancelled = true;
+    };
   }, [contextKey, key]);
 
   const hydrated = response?.key === key;

--- a/src/utils/discoverStateOverlay.test.ts
+++ b/src/utils/discoverStateOverlay.test.ts
@@ -1,0 +1,89 @@
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyDiscoverStateOverlay,
+  getDiscoverStateInputs,
+} from './discoverStateOverlay';
+
+describe('Discover state overlays', () => {
+  it('collects and deduplicates supported catalog identifiers', () => {
+    const inputs = getDiscoverStateInputs([
+      {
+        results: [
+          { id: 1, mediaType: 'movie' },
+          { id: 1, mediaType: 'movie' },
+          { id: 'release-group', mediaType: 'album' },
+          { id: 4, mediaType: 'person' },
+        ],
+      },
+    ]);
+
+    assert.deepEqual(inputs, [
+      { mediaType: MediaType.MOVIE, id: 1 },
+      { mediaType: MediaType.MUSIC, id: 'release-group' },
+    ]);
+  });
+
+  it('updates personalized state without changing catalog ordering', () => {
+    const pages: {
+      page: number;
+      results: {
+        id: number;
+        mediaType: string;
+        title: string;
+        mediaInfo?: Record<string, unknown>;
+      }[];
+    }[] = [
+      {
+        page: 1,
+        results: [
+          { id: 1, mediaType: 'movie', title: 'First' },
+          { id: 2, mediaType: 'movie', title: 'Second' },
+        ],
+      },
+    ];
+    const updated = applyDiscoverStateOverlay(pages, {
+      revision: 'state-revision',
+      generatedAt: new Date(0).toISOString(),
+      items: [
+        {
+          key: `${MediaType.MOVIE}:1`,
+          mediaType: MediaType.MOVIE,
+          id: 1,
+          media: {
+            id: 10,
+            status: MediaStatus.PROCESSING,
+            status4k: MediaStatus.UNKNOWN,
+            updatedAt: new Date(0).toISOString(),
+          },
+          request: {
+            id: 20,
+            status: MediaRequestStatus.APPROVED,
+            is4k: false,
+            updatedAt: new Date(0).toISOString(),
+          },
+          watchlisted: true,
+        },
+      ],
+    });
+
+    assert.deepEqual(
+      updated[0].results.map((item) => item.title),
+      ['First', 'Second']
+    );
+    assert.equal(
+      updated[0].results[0].mediaInfo?.status,
+      MediaStatus.PROCESSING
+    );
+    assert.equal(
+      (updated[0].results[0].mediaInfo?.watchlists as unknown[]).length,
+      1
+    );
+    assert.equal(updated[0].results[1], pages[0].results[1]);
+  });
+});

--- a/src/utils/discoverStateOverlay.ts
+++ b/src/utils/discoverStateOverlay.ts
@@ -1,0 +1,105 @@
+import { MediaType } from '@server/constants/media';
+import type {
+  DiscoverHomeStateItem,
+  DiscoverHomeStateResponse,
+} from '@server/interfaces/api/discoverHomeInterfaces';
+
+interface CatalogItem {
+  id: number | string;
+  mediaType: string;
+  mediaInfo?: object;
+}
+
+interface CatalogPage {
+  results: CatalogItem[];
+}
+
+const getStateMediaType = (mediaType: string): MediaType | undefined => {
+  switch (mediaType) {
+    case 'movie':
+      return MediaType.MOVIE;
+    case 'tv':
+      return MediaType.TV;
+    case 'album':
+      return MediaType.MUSIC;
+    case 'book':
+      return MediaType.BOOK;
+    default:
+      return undefined;
+  }
+};
+
+export const getDiscoverStateInputs = (pages: CatalogPage[]) => {
+  const inputs = new Map<
+    string,
+    { mediaType: MediaType; id: number | string }
+  >();
+
+  for (const page of pages) {
+    for (const item of page.results) {
+      const mediaType = getStateMediaType(item.mediaType);
+
+      if (!mediaType) {
+        continue;
+      }
+
+      const key = `${mediaType}:${item.id}`;
+      inputs.set(key, { mediaType, id: item.id });
+
+      if (inputs.size === 100) {
+        return [...inputs.values()];
+      }
+    }
+  }
+
+  return [...inputs.values()];
+};
+
+const applyState = (
+  item: CatalogItem,
+  state: DiscoverHomeStateItem
+): CatalogItem => {
+  if (!state.media && !item.mediaInfo) {
+    return item;
+  }
+
+  const mediaInfo: Record<string, unknown> = { ...(item.mediaInfo ?? {}) };
+
+  if (state.media) {
+    mediaInfo.id = state.media.id;
+    mediaInfo.status = state.media.status;
+    mediaInfo.status4k = state.media.status4k;
+    mediaInfo.updatedAt = state.media.updatedAt;
+  }
+
+  mediaInfo.watchlists = state.watchlisted
+    ? ((mediaInfo.watchlists as unknown[])?.length ?? 0) > 0
+      ? mediaInfo.watchlists
+      : [{ id: -1 }]
+    : [];
+  mediaInfo.requests = state.request ? [state.request] : [];
+
+  return { ...item, mediaInfo };
+};
+
+export const applyDiscoverStateOverlay = <T extends CatalogPage>(
+  pages: T[],
+  response: DiscoverHomeStateResponse
+): T[] => {
+  const stateByKey = new Map(response.items.map((item) => [item.key, item]));
+
+  return pages.map(
+    (page) =>
+      ({
+        ...page,
+        results: page.results.map((item) => {
+          const mediaType = getStateMediaType(item.mediaType);
+          const state = mediaType
+            ? stateByKey.get(`${mediaType}:${item.id}`)
+            : undefined;
+
+          return state ? applyState(item, state) : item;
+        }),
+      }) as T
+  );
+};


### PR DESCRIPTION
## Description

Why are we not caching the Discover homepage? If I go away for 30+ minutes and come back, it reloads everything. This page should basically be static, and only a diff needs to run.

This change adds persistent stale-first homepage row snapshots, a lightweight manifest for layout and user-state revisions, a personalized state overlay, and schema-versioned service-worker caches. Cached rows render immediately while stale data revalidates in the background. Cache data is partitioned by user and incompatible schemas are removed without clearing compatible caches during every deployment.

No database migration is required.

**AI Disclosure:** Codex was used to implement, review, test, rebase, and prepare this pull request. The contributor directed the feature scope, reviewed the live behavior, and explicitly requested submission.

## How Has This Been Tested?

- `pnpm test` — 634 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm i18n:extract`
- Deployed the same feature commits to a Kubernetes environment and verified the homepage manifest, conditional `304` response, personalized state overlay, service-worker asset, application routes, and warm-cache behavior

## Screenshots / Logs (if applicable)

Not applicable. The change preserves the existing homepage layout and changes loading and revalidation behavior.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)