### PR TITLE
fix(ci): skip Cypress recording without dashboard key

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,7 +75,9 @@ jobs:
           start: pnpm start
           wait-on: 'http://localhost:5056'
           config: baseUrl=http://localhost:5056
-          record: true
+          # Forks and installations without a Cypress Dashboard key must still
+          # run the suite instead of failing before the first spec starts.
+          record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Prevent main-branch and fork Cypress jobs from failing before test execution when no Cypress Dashboard record key is configured. Dashboard recording remains enabled when the secret exists.

## How Has This Been Tested?

- Full Cypress suite: 71/71 passed
- Unit tests passed
- Lint, formatting, production build, i18n, and CodeQL passed

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed AI assistance: OpenAI Codex was used to diagnose, implement, and validate this CI fix.
- [x] Documentation is not affected.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration is not required.