### PR TITLE
fix(security): close remaining CodeQL alerts

### DIFF
--- a/.github/workflows/package-smoke-disabled.yml
+++ b/.github/workflows/package-smoke-disabled.yml
@@ -7,6 +7,9 @@ on:
         description: Existing release tag to validate
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   disabled:
     if: false

--- a/public/sw.js
+++ b/public/sw.js
@@ -327,7 +327,11 @@ const staleWhileRevalidate = async (request, cacheRequest, cacheType) => {
 };
 
 self.addEventListener('message', (event) => {
-  if (event.data?.type !== 'SET_CACHE_USER' || !event.source?.id) {
+  if (
+    event.origin !== self.location.origin ||
+    event.data?.type !== 'SET_CACHE_USER' ||
+    !event.source?.id
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Description

Close the final two open CodeQL alerts by limiting the disabled package smoke workflow token to read-only repository contents and rejecting cross-origin service-worker cache identity messages.

## How Has This Been Tested?

- Prettier checks pass for both changed files
- Diff whitespace validation passes
- CodeQL must pass on this PR

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed AI assistance: OpenAI Codex was used to diagnose, implement, and validate these security fixes.
- [x] Documentation is not affected.
- [x] Existing tests passed on the preceding main validation; this PR is additionally gated by full CI.
- [x] Successful build is required by PR CI.
- [x] Translation keys are not affected.
- [x] Database migration is not required.