### PR TITLE
fix(discover): fill cached media sliders

### DIFF
--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -20,6 +20,10 @@ import {
   getDiscoverStateInputs,
 } from '@app/utils/discoverStateOverlay';
 import {
+  MEDIA_SLIDER_TITLE_LIMIT,
+  shouldShowMoreSliderCard,
+} from '@app/utils/mediaSlider';
+import {
   ArrowPathIcon,
   ArrowRightCircleIcon,
 } from '@heroicons/react/24/outline';
@@ -327,14 +331,14 @@ const MediaSlider = ({
     [blocklistVisibility, titles]
   );
   const visibleTitles = useMemo(
-    () => renderableTitles.slice(0, 20),
+    () => renderableTitles.slice(0, MEDIA_SLIDER_TITLE_LIMIT),
     [renderableTitles]
   );
 
   const shouldLoadMore =
-    renderableTitles.length < 24 &&
+    renderableTitles.length < MEDIA_SLIDER_TITLE_LIMIT + 4 &&
     size < 5 &&
-    (data?.[0]?.totalResults ?? 0) > size * 20;
+    (data?.[0]?.totalResults ?? 0) > size * MEDIA_SLIDER_TITLE_LIMIT;
 
   useEffect(() => {
     if (shouldLoadMore) {
@@ -381,7 +385,7 @@ const MediaSlider = ({
   const showMorePosters = useMemo(
     () =>
       renderableTitles
-        .slice(20, 24)
+        .slice(MEDIA_SLIDER_TITLE_LIMIT, MEDIA_SLIDER_TITLE_LIMIT + 4)
         .map((title) =>
           title.mediaType !== 'person' && title.mediaType !== 'artist'
             ? title.posterPath
@@ -489,7 +493,13 @@ const MediaSlider = ({
       }
     });
 
-    if (linkUrl && renderableTitles.length > 20) {
+    const shouldShowMore = shouldShowMoreSliderCard({
+      hasLink: !!linkUrl,
+      loadedTitleCount: renderableTitles.length,
+      totalResults: data?.[0]?.totalResults ?? 0,
+    });
+
+    if (linkUrl && shouldShowMore) {
       cardTitles.push(
         <ShowMoreCard key="show-more" url={linkUrl} posters={showMorePosters} />
       );
@@ -497,6 +507,7 @@ const MediaSlider = ({
 
     return cardTitles;
   }, [
+    data,
     linkUrl,
     prioritizeFirstRow,
     renderableTitles.length,
@@ -510,8 +521,9 @@ const MediaSlider = ({
 
   const hasReachedEnd =
     !!data &&
-    ((data[data.length - 1]?.results.length ?? 0) < 20 ||
-      (data[data.length - 1]?.totalResults ?? 0) <= size * 20 ||
+    ((data[data.length - 1]?.results.length ?? 0) < MEDIA_SLIDER_TITLE_LIMIT ||
+      (data[data.length - 1]?.totalResults ?? 0) <=
+        size * MEDIA_SLIDER_TITLE_LIMIT ||
       size >= 5);
 
   if (hideWhenEmpty && data && hasReachedEnd && !renderableTitles.length) {

--- a/src/utils/mediaSlider.test.ts
+++ b/src/utils/mediaSlider.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { shouldShowMoreSliderCard } from './mediaSlider';
+
+describe('media slider pagination', () => {
+  it('shows the navigation card for a cached first page with more results', () => {
+    assert.equal(
+      shouldShowMoreSliderCard({
+        hasLink: true,
+        loadedTitleCount: 20,
+        totalResults: 100,
+      }),
+      true
+    );
+  });
+
+  it('does not show the navigation card when the first page is complete', () => {
+    assert.equal(
+      shouldShowMoreSliderCard({
+        hasLink: true,
+        loadedTitleCount: 20,
+        totalResults: 20,
+      }),
+      false
+    );
+  });
+
+  it('requires a destination even when more results exist', () => {
+    assert.equal(
+      shouldShowMoreSliderCard({
+        hasLink: false,
+        loadedTitleCount: 20,
+        totalResults: 100,
+      }),
+      false
+    );
+  });
+});

--- a/src/utils/mediaSlider.ts
+++ b/src/utils/mediaSlider.ts
@@ -1,0 +1,14 @@
+export const MEDIA_SLIDER_TITLE_LIMIT = 20;
+
+export const shouldShowMoreSliderCard = ({
+  hasLink,
+  loadedTitleCount,
+  totalResults,
+}: {
+  hasLink: boolean;
+  loadedTitleCount: number;
+  totalResults: number;
+}): boolean =>
+  hasLink &&
+  (loadedTitleCount > MEDIA_SLIDER_TITLE_LIMIT ||
+    totalResults > MEDIA_SLIDER_TITLE_LIMIT);


### PR DESCRIPTION
## Description

Fixes cached homepage media sliders rendering one result short when a full cached page has more results available. The slider now uses total-result metadata when deciding whether to reserve the See More tile.

**AI Disclosure:** Codex was used for implementation, rebasing, testing, and preparation of this pull request.

## How Has This Been Tested?

- 3 focused media-slider tests pass.
- TypeScript typechecking passes.
- ESLint and Prettier checks pass on changed files.

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are needed for this bug fix.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no translation keys changed)
- [x] Database migration (not required)