### PR TITLE
fix(discover): append pagination and preload thumbnails earlier

### DIFF
--- a/cypress/e2e/theme-and-jitter.cy.ts
+++ b/cypress/e2e/theme-and-jitter.cy.ts
@@ -177,4 +177,53 @@ describe('Theme picker and seeded discovery refresh', () => {
       expect(new Set(bookSeeds).size).to.be.greaterThan(1);
     });
   });
+
+  it('appends another ranked book page without reloading the first page', () => {
+    cy.viewport(1400, 900);
+
+    let firstPageRequests = 0;
+    const firstPageBooks = Array.from({ length: 20 }, (_, index) =>
+      makeBook(`First page book ${index + 1}`, `first-page-${index + 1}`)
+    );
+
+    cy.intercept('GET', '/api/v1/discover/books*', (req) => {
+      if (req.query.page === '2') {
+        req.reply({
+          page: 2,
+          totalPages: 2,
+          totalResults: 41,
+          results: [makeBook('Appended book', 'second-page-1')],
+        });
+        return;
+      }
+
+      firstPageRequests += 1;
+      req.reply({
+        page: 1,
+        totalPages: 2,
+        totalResults: 41,
+        results: firstPageBooks,
+      });
+    }).as('books');
+
+    cy.visit('/discover/books');
+    cy.wait('@books');
+    cy.get('[data-testid=title-card]')
+      .should('have.length', 20)
+      .first()
+      .then(($firstCard) => {
+        cy.scrollTo('bottom');
+        cy.wait('@books').its('request.query.page').should('eq', '2');
+
+        cy.get('[data-testid=title-card]')
+          .should('have.length', 21)
+          .first()
+          .should(($currentFirstCard) => {
+            expect($currentFirstCard[0]).to.eq($firstCard[0]);
+          });
+      });
+    cy.then(() => {
+      expect(firstPageRequests).to.eq(1);
+    });
+  });
 });

--- a/cypress/e2e/theme-and-jitter.cy.ts
+++ b/cypress/e2e/theme-and-jitter.cy.ts
@@ -178,8 +178,8 @@ describe('Theme picker and seeded discovery refresh', () => {
     });
   });
 
-  it('appends another ranked book page without reloading the first page', () => {
-    cy.viewport(1400, 900);
+  it('prefetches and appends another ranked book page before reaching the bottom', () => {
+    cy.viewport(500, 700);
 
     let firstPageRequests = 0;
     const firstPageBooks = Array.from({ length: 20 }, (_, index) =>
@@ -212,7 +212,15 @@ describe('Theme picker and seeded discovery refresh', () => {
       .should('have.length', 20)
       .first()
       .then(($firstCard) => {
-        cy.scrollTo('bottom');
+        cy.window().then((win) => {
+          const maxScrollTop =
+            win.document.documentElement.scrollHeight - win.innerHeight;
+          const prefetchScrollTop = maxScrollTop - win.innerHeight / 2;
+
+          expect(prefetchScrollTop).to.be.greaterThan(0);
+          cy.scrollTo(0, prefetchScrollTop);
+          cy.window().its('scrollY').should('be.lessThan', maxScrollTop);
+        });
         cy.wait('@books').its('request.query.page').should('eq', '2');
 
         cy.get('[data-testid=title-card]')

--- a/src/components/Common/ListView/index.tsx
+++ b/src/components/Common/ListView/index.tsx
@@ -116,7 +116,7 @@ const ListView = ({
   );
   const itemCards = useMemo(
     () =>
-      visibleItems?.map((title, index) => {
+      visibleItems?.map((title) => {
         let titleCard: React.ReactNode;
 
         switch (title.mediaType) {
@@ -247,7 +247,7 @@ const ListView = ({
             return null;
         }
 
-        return <li key={`${title.id}-${index}`}>{titleCard}</li>;
+        return <li key={`${title.mediaType}:${title.id}`}>{titleCard}</li>;
       }),
     [
       visibleItems,

--- a/src/components/TitleCard/LibraryTitleCard.tsx
+++ b/src/components/TitleCard/LibraryTitleCard.tsx
@@ -33,6 +33,7 @@ const LibraryTitleCard = ({
 }: LibraryTitleCardProps) => {
   const { hasPermission } = useUser();
   const { ref, inView } = useInView({
+    rootMargin: '100% 0px',
     triggerOnce: true,
   });
   const normalizedId = normalizeExternalTitleId(type, id).toString();

--- a/src/components/TitleCard/TmdbTitleCard.tsx
+++ b/src/components/TitleCard/TmdbTitleCard.tsx
@@ -34,6 +34,7 @@ const TmdbTitleCard = ({
   const { hasPermission } = useUser();
 
   const { ref, inView } = useInView({
+    rootMargin: '100% 0px',
     triggerOnce: true,
   });
   const url = useMemo(

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -154,8 +154,12 @@ const useDiscover = <
       )}:${randomizeOrder ? 'random' : 'stable'}`,
     [endpoint, options, randomizeOrder, user?.id]
   );
-  const fallbackData =
+  const persistentFallbackData =
     usePersistentResponse<(BaseSearchResult<T> & S)[]>(fallbackCacheKey);
+  // A randomized view gets a new seed on each mount. Restoring results produced
+  // with the previous seed would paint one lineup and then replace it as soon as
+  // the current request completes.
+  const fallbackData = randomizeOrder ? undefined : persistentFallbackData;
   const {
     data,
     error,
@@ -186,7 +190,9 @@ const useDiscover = <
     },
     {
       initialSize: 1,
-      revalidateFirstPage: true,
+      // Loading the next page should only append that page. Availability and
+      // request state are refreshed explicitly when a cached view is restored.
+      revalidateFirstPage: false,
       dedupingInterval: 30000,
       revalidateOnFocus: false,
       fallbackData,
@@ -322,10 +328,10 @@ const useDiscover = <
   }, [setSize, shouldScanNextFilteredPage]);
 
   useEffect(() => {
-    if (data?.length && titles.length) {
+    if (!randomizeOrder && data?.length && titles.length) {
       setPersistentResponse(fallbackCacheKey, data);
     }
-  }, [data, fallbackCacheKey, titles.length]);
+  }, [data, fallbackCacheKey, randomizeOrder, titles.length]);
 
   useEffect(() => {
     if (error && titles.length) {

--- a/src/hooks/useVerticalScroll.ts
+++ b/src/hooks/useVerticalScroll.ts
@@ -2,7 +2,6 @@ import type { MutableRefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const IS_SCROLLING_CHECK_THROTTLE = 200;
-const BUFFER_HEIGHT = 200;
 const BOTTOM_RECHECK_INTERVAL = 500;
 
 /**
@@ -33,7 +32,7 @@ const useVerticalScroll = (
       );
       if (
         window.innerHeight + scrollTop >=
-        document.documentElement.offsetHeight - BUFFER_HEIGHT
+        document.documentElement.offsetHeight - window.innerHeight
       ) {
         callback();
       }

--- a/src/utils/swrCache.ts
+++ b/src/utils/swrCache.ts
@@ -68,13 +68,13 @@ export const setPersistentResponse = <T>(key: string, data: T | undefined) => {
 };
 
 export const usePersistentResponse = <T>(key: string): T | undefined => {
-  const [data, setData] = useState<T>();
+  const [response, setResponse] = useState<{ key: string; data?: T }>();
 
   useEffect(() => {
-    setData(getPersistentResponse<T>(key));
+    setResponse({ key, data: getPersistentResponse<T>(key) });
   }, [key]);
 
-  return data;
+  return response?.key === key ? response.data : undefined;
 };
 
 // SWR's shared in-memory cache handles navigation deduplication. Persisted


### PR DESCRIPTION
## Description

Keeps existing discovery cards mounted while appending paginated results, requests the next page before the viewport reaches the bottom, and starts title-card thumbnail loading earlier. Browser coverage checks that the first page remains stable while the next page is prefetched.

**AI Disclosure:** Codex was used for implementation, rebasing, testing, and preparation of this pull request.

## How Has This Been Tested?

- TypeScript typechecking passes.
- ESLint and Prettier checks pass on changed files.
- Cypress regression coverage is included for stable card identity and early pagination.

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are needed for this behavior fix.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no translation keys changed)
- [x] Database migration (not required)