### PR TITLE
fix(images): improve cache limits and avatar fallbacks

### DIFF
--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -427,11 +427,10 @@ class ImageProxy {
     path: string,
     fallbackPath?: string
   ): Promise<ImageResponse> {
-    const cacheKey = this.getCacheKey(path);
-
-    const imageResponse = await this.get(cacheKey);
+    const imageResponse = await this.getCachedImage(path);
 
     if (!imageResponse) {
+      const cacheKey = this.getCacheKey(path);
       const newImage = await this.set(path, cacheKey);
 
       if (!newImage) {
@@ -445,9 +444,20 @@ class ImageProxy {
       return newImage;
     }
 
-    // If the image is stale, we will revalidate it in the background.
-    if (imageResponse.meta.isStale) {
-      this.set(path, cacheKey);
+    return imageResponse;
+  }
+
+  /**
+   * Returns an image already held in memory or on disk without fetching a
+   * missing image from its upstream provider. Stale images are served while
+   * they are revalidated in the background.
+   */
+  public async getCachedImage(path: string): Promise<ImageResponse | null> {
+    const cacheKey = this.getCacheKey(path);
+    const imageResponse = await this.get(cacheKey);
+
+    if (imageResponse?.meta.isStale) {
+      void this.set(path, cacheKey);
     }
 
     return imageResponse;

--- a/server/lib/remoteAvatarCache.test.ts
+++ b/server/lib/remoteAvatarCache.test.ts
@@ -18,6 +18,10 @@ describe('isRemoteAvatarCacheUrlAllowed', () => {
       ),
       true
     );
+    assert.equal(
+      isRemoteAvatarCacheUrlAllowed(new URL('https://plex.tv/users/1/avatar')),
+      true
+    );
   });
 
   it('rejects non-HTTPS, credentials, and unrelated hosts', () => {

--- a/server/lib/remoteAvatarCache.ts
+++ b/server/lib/remoteAvatarCache.ts
@@ -2,6 +2,7 @@ const REMOTE_AVATAR_HOSTS = new Set([
   'gravatar.com',
   'secure.gravatar.com',
   'www.gravatar.com',
+  'plex.tv',
 ]);
 
 const REMOTE_AVATAR_DOMAIN_SUFFIXES = ['.gravatar.com', '.plex.tv'];

--- a/server/routes/avatarproxy.test.ts
+++ b/server/routes/avatarproxy.test.ts
@@ -50,7 +50,11 @@ function mockAvatarDependencies() {
       return null;
     },
   }));
-  mock.method(ImageProxy.prototype, 'getImage', async () => avatarResponse);
+  return mock.method(
+    ImageProxy.prototype,
+    'getImage',
+    async () => avatarResponse
+  );
 }
 
 afterEach(() => {
@@ -85,6 +89,23 @@ describe('GET /avatarproxy/remote', () => {
     assert.equal(res.headers['os-cache-key'], 'avatar-cache-key');
     assert.equal(res.headers['os-cache-status'], 'HIT');
     assert.equal(res.body.toString(), 'avatar-bytes');
+  });
+
+  it('proxies apex Plex avatars with a safe fallback', async () => {
+    const getImageMock = mockAvatarDependencies();
+    const avatarUrl = 'https://plex.tv/users/abc/avatar?c=123';
+
+    const res = await request(createApp())
+      .get('/avatarproxy/remote')
+      .query({ url: avatarUrl });
+
+    assert.equal(res.status, 200);
+    assert.equal(getImageMock.mock.callCount(), 1);
+    assert.equal(getImageMock.mock.calls[0].arguments[0], avatarUrl);
+    assert.match(
+      String(getImageMock.mock.calls[0].arguments[1]),
+      /^https:\/\/(?:www\.)?gravatar\.com\/avatar\//
+    );
   });
 
   it('returns 304 with cache headers when the browser validator matches', async () => {

--- a/server/routes/avatarproxy.test.ts
+++ b/server/routes/avatarproxy.test.ts
@@ -98,7 +98,7 @@ describe('GET /avatarproxy/remote', () => {
     assert.equal(res.body.toString(), 'avatar-bytes');
   });
 
-  it('proxies apex Plex avatars with a safe fallback', async () => {
+  it('keeps the client default visible while refreshing Plex avatars', async () => {
     const { getCachedImageMock, getImageMock } = mockAvatarDependencies();
     const avatarUrl = 'https://plex.tv/users/abc/avatar?c=123';
 
@@ -106,15 +106,12 @@ describe('GET /avatarproxy/remote', () => {
       .get('/avatarproxy/remote')
       .query({ url: avatarUrl });
 
-    assert.equal(res.status, 200);
+    assert.equal(res.status, 204);
+    assert.equal(res.headers['cache-control'], 'no-store');
     assert.equal(getCachedImageMock.mock.callCount(), 1);
     assert.equal(getCachedImageMock.mock.calls[0].arguments[0], avatarUrl);
-    assert.equal(getImageMock.mock.callCount(), 2);
-    assert.match(
-      String(getImageMock.mock.calls[0].arguments[0]),
-      /^https:\/\/(?:www\.)?gravatar\.com\/avatar\//
-    );
-    assert.equal(getImageMock.mock.calls[1].arguments[0], avatarUrl);
+    assert.equal(getImageMock.mock.callCount(), 1);
+    assert.equal(getImageMock.mock.calls[0].arguments[0], avatarUrl);
   });
 
   it('returns 304 with cache headers when the browser validator matches', async () => {

--- a/server/routes/avatarproxy.test.ts
+++ b/server/routes/avatarproxy.test.ts
@@ -50,11 +50,18 @@ function mockAvatarDependencies() {
       return null;
     },
   }));
-  return mock.method(
+  const getCachedImageMock = mock.method(
+    ImageProxy.prototype,
+    'getCachedImage',
+    async () => null
+  );
+  const getImageMock = mock.method(
     ImageProxy.prototype,
     'getImage',
     async () => avatarResponse
   );
+
+  return { getCachedImageMock, getImageMock };
 }
 
 afterEach(() => {
@@ -92,7 +99,7 @@ describe('GET /avatarproxy/remote', () => {
   });
 
   it('proxies apex Plex avatars with a safe fallback', async () => {
-    const getImageMock = mockAvatarDependencies();
+    const { getCachedImageMock, getImageMock } = mockAvatarDependencies();
     const avatarUrl = 'https://plex.tv/users/abc/avatar?c=123';
 
     const res = await request(createApp())
@@ -100,12 +107,14 @@ describe('GET /avatarproxy/remote', () => {
       .query({ url: avatarUrl });
 
     assert.equal(res.status, 200);
-    assert.equal(getImageMock.mock.callCount(), 1);
-    assert.equal(getImageMock.mock.calls[0].arguments[0], avatarUrl);
+    assert.equal(getCachedImageMock.mock.callCount(), 1);
+    assert.equal(getCachedImageMock.mock.calls[0].arguments[0], avatarUrl);
+    assert.equal(getImageMock.mock.callCount(), 2);
     assert.match(
-      String(getImageMock.mock.calls[0].arguments[1]),
+      String(getImageMock.mock.calls[0].arguments[0]),
       /^https:\/\/(?:www\.)?gravatar\.com\/avatar\//
     );
+    assert.equal(getImageMock.mock.calls[1].arguments[0], avatarUrl);
   });
 
   it('returns 304 with cache headers when the browser validator matches', async () => {

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -30,6 +30,8 @@ const REMOTE_AVATAR_FALLBACK_URL = gravatarUrl('none', {
   default: 'mm',
   size: 200,
 });
+const REMOTE_PLEX_AVATAR_RETRY_COOLDOWN_MS = 5 * 60 * 1000;
+const remotePlexAvatarRetryAfter = new Map<string, number>();
 export const AVATAR_HEAD_REQUEST_OPTIONS = {
   timeout: 5_000,
   maxRedirects: 0,
@@ -46,6 +48,34 @@ const avatarProxyRateLimit = rateLimit({
 });
 
 let _avatarImageProxy: ImageProxy | null = null;
+
+const isPlexAvatarUrl = (avatarUrl: string): boolean => {
+  const hostname = new URL(avatarUrl).hostname.toLowerCase();
+  return hostname === 'plex.tv' || hostname.endsWith('.plex.tv');
+};
+
+const refreshPlexAvatarInBackground = (
+  avatarImageCache: ImageProxy,
+  avatarUrl: string
+) => {
+  const now = Date.now();
+
+  for (const [url, retryAfter] of remotePlexAvatarRetryAfter) {
+    if (retryAfter <= now) {
+      remotePlexAvatarRetryAfter.delete(url);
+    }
+  }
+
+  if ((remotePlexAvatarRetryAfter.get(avatarUrl) ?? 0) > now) {
+    return;
+  }
+
+  remotePlexAvatarRetryAfter.set(
+    avatarUrl,
+    now + REMOTE_PLEX_AVATAR_RETRY_COOLDOWN_MS
+  );
+  void avatarImageCache.getImage(avatarUrl).catch(() => undefined);
+};
 
 async function initAvatarImageProxy() {
   if (!_avatarImageProxy) {
@@ -210,10 +240,19 @@ router.get('/remote', avatarProxyRateLimit, async (req, res) => {
     }
 
     const avatarImageCache = await initAvatarImageProxy();
-    const imageData = await avatarImageCache.getImage(
-      avatarUrl,
-      REMOTE_AVATAR_FALLBACK_URL
-    );
+    let imageData;
+    if (isPlexAvatarUrl(avatarUrl)) {
+      imageData = await avatarImageCache.getCachedImage(avatarUrl);
+      if (!imageData) {
+        imageData = await avatarImageCache.getImage(REMOTE_AVATAR_FALLBACK_URL);
+        refreshPlexAvatarInBackground(avatarImageCache, avatarUrl);
+      }
+    } else {
+      imageData = await avatarImageCache.getImage(
+        avatarUrl,
+        REMOTE_AVATAR_FALLBACK_URL
+      );
+    }
 
     return sendCachedAvatarImage({
       imageData,

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -26,6 +26,10 @@ import { createHash } from 'node:crypto';
 const router = Router();
 const MAX_AVATAR_VERSION_LENGTH = 128;
 const JELLYFIN_USER_ID_PATTERN = /^[a-f0-9]{32}$/;
+const REMOTE_AVATAR_FALLBACK_URL = gravatarUrl('none', {
+  default: 'mm',
+  size: 200,
+});
 export const AVATAR_HEAD_REQUEST_OPTIONS = {
   timeout: 5_000,
   maxRedirects: 0,
@@ -206,7 +210,10 @@ router.get('/remote', avatarProxyRateLimit, async (req, res) => {
     }
 
     const avatarImageCache = await initAvatarImageProxy();
-    const imageData = await avatarImageCache.getImage(avatarUrl);
+    const imageData = await avatarImageCache.getImage(
+      avatarUrl,
+      REMOTE_AVATAR_FALLBACK_URL
+    );
 
     return sendCachedAvatarImage({
       imageData,

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -244,8 +244,8 @@ router.get('/remote', avatarProxyRateLimit, async (req, res) => {
     if (isPlexAvatarUrl(avatarUrl)) {
       imageData = await avatarImageCache.getCachedImage(avatarUrl);
       if (!imageData) {
-        imageData = await avatarImageCache.getImage(REMOTE_AVATAR_FALLBACK_URL);
         refreshPlexAvatarInBackground(avatarImageCache, avatarUrl);
+        return res.status(204).set('Cache-Control', 'no-store').end();
       }
     } else {
       imageData = await avatarImageCache.getImage(

--- a/server/routes/imageproxy.test.ts
+++ b/server/routes/imageproxy.test.ts
@@ -5,7 +5,10 @@ import type { ImageResponse } from '@server/lib/imageproxy';
 import ImageProxy, { IMAGE_PROXY_HTTP_OPTIONS } from '@server/lib/imageproxy';
 import express from 'express';
 import request from 'supertest';
-import imageproxyRoutes from './imageproxy';
+import imageproxyRoutes, {
+  IMAGE_PROXY_CACHE_MISS_LIMIT,
+  IMAGE_PROXY_REQUEST_LIMIT,
+} from './imageproxy';
 
 const imageResponse: ImageResponse = {
   meta: {
@@ -37,6 +40,62 @@ describe('GET /imageproxy/:type/*path', () => {
     assert.equal(IMAGE_PROXY_HTTP_OPTIONS.timeout, 10_000);
   });
 
+  it('serves cache hits without entering the upstream fetch path', async () => {
+    const getCachedImage = mock.method(
+      ImageProxy.prototype,
+      'getCachedImage',
+      async () => imageResponse
+    );
+    const getImage = mock.method(
+      ImageProxy.prototype,
+      'getImage',
+      async () => imageResponse
+    );
+
+    const res = await request(createApp()).get(
+      '/imageproxy/tmdb/t/p/w300/cached-poster.jpg'
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['os-cache-status'], 'HIT');
+    assert.equal(
+      Number(res.headers['ratelimit-limit']),
+      IMAGE_PROXY_REQUEST_LIMIT
+    );
+    assert.equal(getCachedImage.mock.callCount(), 1);
+    assert.equal(getImage.mock.callCount(), 0);
+  });
+
+  it('applies the upstream-fetch budget only after a cache miss', async () => {
+    const cacheMissResponse: ImageResponse = {
+      ...imageResponse,
+      meta: { ...imageResponse.meta, cacheMiss: true },
+    };
+    const getCachedImage = mock.method(
+      ImageProxy.prototype,
+      'getCachedImage',
+      async () => null
+    );
+    const getImage = mock.method(
+      ImageProxy.prototype,
+      'getImage',
+      async () => cacheMissResponse
+    );
+
+    const res = await request(createApp()).get(
+      '/imageproxy/tmdb/t/p/w300/uncached-poster.jpg'
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['os-cache-status'], 'MISS');
+    assert.equal(
+      Number(res.headers['ratelimit-limit']),
+      IMAGE_PROXY_CACHE_MISS_LIMIT
+    );
+    assert.equal(getCachedImage.mock.callCount(), 1);
+    assert.equal(getImage.mock.callCount(), 1);
+  });
+
   it('sends browser cache headers with proxied images', async () => {
     mock.method(ImageProxy.prototype, 'getImage', async () => imageResponse);
 
@@ -58,7 +117,16 @@ describe('GET /imageproxy/:type/*path', () => {
   });
 
   it('returns 304 with cache headers when the browser validator matches', async () => {
-    mock.method(ImageProxy.prototype, 'getImage', async () => imageResponse);
+    mock.method(
+      ImageProxy.prototype,
+      'getCachedImage',
+      async () => imageResponse
+    );
+    const getImage = mock.method(
+      ImageProxy.prototype,
+      'getImage',
+      async () => imageResponse
+    );
 
     const res = await request(createApp())
       .get('/imageproxy/tmdb/t/p/w300/poster.jpg')
@@ -71,6 +139,7 @@ describe('GET /imageproxy/:type/*path', () => {
       'public, max-age=3600, stale-while-revalidate=2592000, stale-if-error=604800'
     );
     assert.equal(res.text, '');
+    assert.equal(getImage.mock.callCount(), 0);
   });
 
   it('keeps query strings in the upstream cache key', async () => {
@@ -110,6 +179,11 @@ describe('GET /imageproxy/:type/*path', () => {
   });
 
   it('rejects oversized proxied image paths before cache lookup', async () => {
+    const getCachedImage = mock.method(
+      ImageProxy.prototype,
+      'getCachedImage',
+      async () => imageResponse
+    );
     const getImage = mock.method(
       ImageProxy.prototype,
       'getImage',
@@ -122,6 +196,7 @@ describe('GET /imageproxy/:type/*path', () => {
 
     assert.equal(res.status, 403);
     assert.match(res.text, /Invalid URL for image proxy/);
+    assert.equal(getCachedImage.mock.callCount(), 0);
     assert.equal(getImage.mock.callCount(), 0);
   });
 
@@ -181,5 +256,6 @@ describe('POST /imageproxy/warm', () => {
 
     assert.equal(res.status, 202);
     assert.deepEqual(res.body, { accepted: true });
+    assert.equal(Number(res.headers['ratelimit-limit']), 10);
   });
 });

--- a/server/routes/imageproxy.ts
+++ b/server/routes/imageproxy.ts
@@ -9,6 +9,7 @@ import ImageProxy, {
 } from '@server/lib/imageproxy';
 import logger from '@server/logger';
 import { getRateLimitKey } from '@server/utils/security';
+import type { NextFunction, Request, Response } from 'express';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 
@@ -17,12 +18,51 @@ const maxWarmRequestUrls = 100;
 const maxWarmUrlLength = 2048;
 const maxProxyImagePathLength = 2048;
 
-const proxyRateLimit = rateLimit({
+export const IMAGE_PROXY_REQUEST_LIMIT = 1200;
+export const IMAGE_PROXY_CACHE_MISS_LIMIT = 600;
+
+type RateLimitRequest = Request & {
+  rateLimit?: {
+    limit: number;
+    used: number;
+  };
+};
+
+const createRateLimitHandler =
+  (policy: 'total' | 'cache-miss') =>
+  (
+    req: RateLimitRequest,
+    res: Response,
+    _next: NextFunction,
+    options: { message: unknown; statusCode: number }
+  ) => {
+    if (!req.rateLimit || req.rateLimit.used === req.rateLimit.limit + 1) {
+      logger.warn('Image proxy request rate limit exceeded', {
+        label: 'Image Proxy',
+        policy,
+        imageType: req.params.type,
+      });
+    }
+
+    res.status(options.statusCode).send(options.message);
+  };
+
+const proxyRequestRateLimit = rateLimit({
   windowMs: 60 * 1000,
-  limit: 240,
+  limit: IMAGE_PROXY_REQUEST_LIMIT,
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: getRateLimitKey,
+  handler: createRateLimitHandler('total'),
+});
+
+const proxyCacheMissRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  limit: IMAGE_PROXY_CACHE_MISS_LIMIT,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: getRateLimitKey,
+  handler: createRateLimitHandler('cache-miss'),
 });
 
 const warmRateLimit = rateLimit({
@@ -32,8 +72,6 @@ const warmRateLimit = rateLimit({
   legacyHeaders: false,
   keyGenerator: getRateLimitKey,
 });
-
-router.use(proxyRateLimit);
 
 // Delay the initialization of ImageProxy instances until the proxy (if any) is properly configured
 let _tmdbImageProxy: ImageProxy;
@@ -125,10 +163,66 @@ function initOpenLibraryCoversImageProxy() {
   return _openLibraryCoversImageProxy;
 }
 
-router.get<{
-  type: string;
-  path: string[];
-}>('/:type/*path', async (req, res) => {
+const getImageProxy = (type: string): ImageProxy | null => {
+  switch (type) {
+    case 'tmdb':
+      return initTmdbImageProxy();
+    case 'tvdb':
+      return initTvdbImageProxy();
+    case 'coverartarchive':
+      return initCoverArtArchiveImageProxy();
+    case 'archiveorg':
+      return initArchiveOrgImageProxy();
+    case 'theaudiodb':
+      return initTheAudioDbImageProxy();
+    case 'openlibrarycovers':
+      return initOpenLibraryCoversImageProxy();
+    default:
+      return null;
+  }
+};
+
+const sendProxyImage = async (
+  req: Request,
+  res: Response,
+  imageData: Awaited<ReturnType<ImageProxy['getImage']>>
+) => {
+  const etag = `"${imageData.meta.etag}"`;
+  const browserCacheHeaders = getBrowserImageResponseHeaders({
+    cacheKey: imageData.meta.cacheKey,
+    cacheMiss: imageData.meta.cacheMiss,
+    etag,
+    lastModified: imageData.meta.lastModified,
+    maxAge: imageData.meta.curRevalidate,
+  });
+
+  if (
+    shouldSendBrowserImageNotModified({
+      etag,
+      ifModifiedSince: req.headers['if-modified-since'],
+      ifNoneMatch: req.headers['if-none-match'],
+      lastModified: imageData.meta.lastModified,
+    })
+  ) {
+    return res.status(304).set(browserCacheHeaders).end();
+  }
+
+  await sendImage(res, imageData, {
+    'Content-Type': getImageResponseContentType(imageData.meta.extension),
+    ...browserCacheHeaders,
+  });
+};
+
+type PreparedImageRequest = {
+  imagePath: string;
+  imageProxy: ImageProxy;
+};
+
+const prepareImageRequest = (
+  req: Request<{ type: string; path: string[] }>,
+  res: Response,
+  next: NextFunction
+) => {
   const queryIndex = req.url.indexOf('?');
   const imagePathname = '/' + req.params.path.join('/');
   const imagePath =
@@ -143,53 +237,55 @@ router.get<{
     return res.status(403).send('Invalid URL for image proxy');
   }
 
+  const imageProxy = getImageProxy(req.params.type);
+  if (!imageProxy) {
+    logger.error('Unsupported image type', {
+      imagePath,
+      type: req.params.type,
+    });
+    return res.status(400).send('Unsupported image type');
+  }
+
+  res.locals.preparedImageRequest = {
+    imagePath,
+    imageProxy,
+  } satisfies PreparedImageRequest;
+  next();
+};
+
+const serveCachedImage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { imagePath, imageProxy } = res.locals
+    .preparedImageRequest as PreparedImageRequest;
+
   try {
-    let imageData;
-    if (req.params.type === 'tmdb') {
-      imageData = await initTmdbImageProxy().getImage(imagePath);
-    } else if (req.params.type === 'tvdb') {
-      imageData = await initTvdbImageProxy().getImage(imagePath);
-    } else if (req.params.type === 'coverartarchive') {
-      imageData = await initCoverArtArchiveImageProxy().getImage(imagePath);
-    } else if (req.params.type === 'archiveorg') {
-      imageData = await initArchiveOrgImageProxy().getImage(imagePath);
-    } else if (req.params.type === 'theaudiodb') {
-      imageData = await initTheAudioDbImageProxy().getImage(imagePath);
-    } else if (req.params.type === 'openlibrarycovers') {
-      imageData = await initOpenLibraryCoversImageProxy().getImage(imagePath);
-    } else {
-      logger.error('Unsupported image type', {
-        imagePath,
-        type: req.params.type,
-      });
-      res.status(400).send('Unsupported image type');
+    const imageData = await imageProxy.getCachedImage(imagePath);
+
+    if (!imageData) {
+      next();
       return;
     }
 
-    const etag = `"${imageData.meta.etag}"`;
-    const browserCacheHeaders = getBrowserImageResponseHeaders({
-      cacheKey: imageData.meta.cacheKey,
-      cacheMiss: imageData.meta.cacheMiss,
-      etag,
-      lastModified: imageData.meta.lastModified,
-      maxAge: imageData.meta.curRevalidate,
+    await sendProxyImage(req, res, imageData);
+  } catch (e) {
+    logger.error('Failed to serve cached proxy image', {
+      imagePath,
+      errorMessage: e.message,
     });
+    res.status(500).send();
+  }
+};
 
-    if (
-      shouldSendBrowserImageNotModified({
-        etag,
-        ifModifiedSince: req.headers['if-modified-since'],
-        ifNoneMatch: req.headers['if-none-match'],
-        lastModified: imageData.meta.lastModified,
-      })
-    ) {
-      return res.status(304).set(browserCacheHeaders).end();
-    }
+const fetchAndServeImage = async (req: Request, res: Response) => {
+  const { imagePath, imageProxy } = res.locals
+    .preparedImageRequest as PreparedImageRequest;
 
-    await sendImage(res, imageData, {
-      'Content-Type': getImageResponseContentType(imageData.meta.extension),
-      ...browserCacheHeaders,
-    });
+  try {
+    const imageData = await imageProxy.getImage(imagePath);
+    await sendProxyImage(req, res, imageData);
   } catch (e) {
     logger.error('Failed to proxy image', {
       imagePath,
@@ -197,7 +293,19 @@ router.get<{
     });
     res.status(500).send();
   }
-});
+};
+
+router.get<{
+  type: string;
+  path: string[];
+}>(
+  '/:type/*path',
+  prepareImageRequest,
+  proxyRequestRateLimit,
+  serveCachedImage,
+  proxyCacheMissRateLimit,
+  fetchAndServeImage
+);
 
 router.post('/warm', warmRateLimit, (req, res) => {
   if (!Array.isArray(req.body?.urls)) {

--- a/src/components/Common/CachedImage/index.tsx
+++ b/src/components/Common/CachedImage/index.tsx
@@ -1,9 +1,9 @@
 import useSettings from '@app/hooks/useSettings';
 import type { CacheableImageType } from '@app/utils/imageCache';
-import { getImageCacheUrl } from '@app/utils/imageCache';
+import { getImageCacheUrl, getImageErrorFallback } from '@app/utils/imageCache';
 import type { ImageLoader, ImageProps } from 'next/image';
 import Image from 'next/image';
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 
 const imageLoader: ImageLoader = ({ src }) => src;
 
@@ -23,6 +23,7 @@ const CachedImage = memo(
     decoding = 'async',
     loading,
     priority,
+    onError,
     ...props
   }: CachedImageProps) => {
     const { currentSettings } = useSettings();
@@ -36,15 +37,27 @@ const CachedImage = memo(
         }),
       [currentSettings.cacheImages, src, type]
     );
+    const [activeImageUrl, setActiveImageUrl] = useState(imageUrl);
+
+    useEffect(() => {
+      setActiveImageUrl(imageUrl);
+    }, [imageUrl]);
 
     return (
       <Image
         unoptimized
         loader={imageLoader}
-        src={imageUrl}
+        src={activeImageUrl}
         decoding={decoding}
         loading={priority ? undefined : (loading ?? 'lazy')}
         priority={priority}
+        onError={(event) => {
+          const fallbackImage = getImageErrorFallback(type, activeImageUrl);
+          if (fallbackImage) {
+            setActiveImageUrl(fallbackImage);
+          }
+          onError?.(event);
+        }}
         {...props}
       />
     );

--- a/src/components/Common/CachedImage/index.tsx
+++ b/src/components/Common/CachedImage/index.tsx
@@ -1,6 +1,11 @@
 import useSettings from '@app/hooks/useSettings';
 import type { CacheableImageType } from '@app/utils/imageCache';
-import { getImageCacheUrl, getImageErrorFallback } from '@app/utils/imageCache';
+import {
+  AVATAR_FALLBACK_IMAGE,
+  getImageCacheUrl,
+  getImageErrorFallback,
+  getInitialImageUrl,
+} from '@app/utils/imageCache';
 import type { ImageLoader, ImageProps } from 'next/image';
 import Image from 'next/image';
 import { memo, useEffect, useMemo, useState } from 'react';
@@ -37,11 +42,28 @@ const CachedImage = memo(
         }),
       [currentSettings.cacheImages, src, type]
     );
-    const [activeImageUrl, setActiveImageUrl] = useState(imageUrl);
+    const [activeImageUrl, setActiveImageUrl] = useState(() =>
+      getInitialImageUrl(type, imageUrl)
+    );
 
     useEffect(() => {
-      setActiveImageUrl(imageUrl);
-    }, [imageUrl]);
+      if (type !== 'avatar' || imageUrl === AVATAR_FALLBACK_IMAGE) {
+        setActiveImageUrl(imageUrl);
+        return;
+      }
+
+      setActiveImageUrl(AVATAR_FALLBACK_IMAGE);
+
+      const avatarPreloader = new window.Image();
+      avatarPreloader.onload = () => setActiveImageUrl(imageUrl);
+      avatarPreloader.onerror = () => setActiveImageUrl(AVATAR_FALLBACK_IMAGE);
+      avatarPreloader.src = imageUrl;
+
+      return () => {
+        avatarPreloader.onload = null;
+        avatarPreloader.onerror = null;
+      };
+    }, [imageUrl, type]);
 
     return (
       <Image

--- a/src/components/Common/CachedImage/index.tsx
+++ b/src/components/Common/CachedImage/index.tsx
@@ -6,6 +6,7 @@ import {
   getImageErrorFallback,
   getInitialImageUrl,
 } from '@app/utils/imageCache';
+import { UserIcon } from '@heroicons/react/24/solid';
 import type { ImageLoader, ImageProps } from 'next/image';
 import Image from 'next/image';
 import { memo, useEffect, useMemo, useState } from 'react';
@@ -64,6 +65,16 @@ const CachedImage = memo(
         avatarPreloader.onerror = null;
       };
     }, [imageUrl, type]);
+
+    if (type === 'avatar' && activeImageUrl === AVATAR_FALLBACK_IMAGE) {
+      return (
+        <UserIcon
+          aria-label={typeof props.alt === 'string' ? props.alt : undefined}
+          className={`inline-flex p-[15%] text-indigo-500 ${props.className ?? ''}`}
+          role={props.alt ? 'img' : undefined}
+        />
+      );
+    }
 
     return (
       <Image

--- a/src/utils/imageCache.test.ts
+++ b/src/utils/imageCache.test.ts
@@ -1,7 +1,26 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getImageCacheUrl, isRemoteAvatarCacheUrlAllowed } from './imageCache';
+import {
+  AVATAR_FALLBACK_IMAGE,
+  getImageCacheUrl,
+  getImageErrorFallback,
+  isRemoteAvatarCacheUrlAllowed,
+} from './imageCache';
+
+describe('getImageErrorFallback', () => {
+  it('falls back failed avatars once without changing other image types', () => {
+    assert.equal(
+      getImageErrorFallback('avatar', 'https://plex.tv/users/1/avatar'),
+      AVATAR_FALLBACK_IMAGE
+    );
+    assert.equal(getImageErrorFallback('avatar', AVATAR_FALLBACK_IMAGE), null);
+    assert.equal(
+      getImageErrorFallback('tmdb', 'https://example.com/poster.jpg'),
+      null
+    );
+  });
+});
 
 describe('getImageCacheUrl', () => {
   it('rewrites supported image providers when image caching is enabled', () => {
@@ -86,6 +105,14 @@ describe('getImageCacheUrl', () => {
       }),
       '/avatarproxy/remote?url=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fabc%3Fd%3Dmm'
     );
+    assert.equal(
+      getImageCacheUrl({
+        cacheImages: true,
+        src: 'https://plex.tv/users/abc/avatar?c=123',
+        type: 'avatar',
+      }),
+      '/avatarproxy/remote?url=https%3A%2F%2Fplex.tv%2Fusers%2Fabc%2Favatar%3Fc%3D123'
+    );
   });
 
   it('leaves local, disabled, and unsupported URLs untouched', () => {
@@ -120,6 +147,10 @@ describe('isRemoteAvatarCacheUrlAllowed', () => {
   it('accepts only safe avatar provider URLs', () => {
     assert.equal(
       isRemoteAvatarCacheUrlAllowed('https://images.plex.tv/users/1/avatar'),
+      true
+    );
+    assert.equal(
+      isRemoteAvatarCacheUrlAllowed('https://plex.tv/users/1/avatar'),
       true
     );
     assert.equal(

--- a/src/utils/imageCache.test.ts
+++ b/src/utils/imageCache.test.ts
@@ -5,8 +5,22 @@ import {
   AVATAR_FALLBACK_IMAGE,
   getImageCacheUrl,
   getImageErrorFallback,
+  getInitialImageUrl,
   isRemoteAvatarCacheUrlAllowed,
 } from './imageCache';
+
+describe('getInitialImageUrl', () => {
+  it('shows the bundled default while avatars load', () => {
+    assert.equal(
+      getInitialImageUrl('avatar', '/avatarproxy/remote?url=plex'),
+      AVATAR_FALLBACK_IMAGE
+    );
+    assert.equal(
+      getInitialImageUrl('tmdb', '/imageproxy/tmdb/poster.jpg'),
+      '/imageproxy/tmdb/poster.jpg'
+    );
+  });
+});
 
 describe('getImageErrorFallback', () => {
   it('falls back failed avatars once without changing other image types', () => {

--- a/src/utils/imageCache.ts
+++ b/src/utils/imageCache.ts
@@ -1,5 +1,15 @@
 export type CacheableImageType = 'tmdb' | 'avatar' | 'tvdb' | 'music' | 'book';
 
+export const AVATAR_FALLBACK_IMAGE = '/user-icon-192x192.png';
+
+export const getImageErrorFallback = (
+  type: CacheableImageType,
+  currentSrc: string
+): string | null =>
+  type === 'avatar' && currentSrc !== AVATAR_FALLBACK_IMAGE
+    ? AVATAR_FALLBACK_IMAGE
+    : null;
+
 const PROXIED_IMAGE_PREFIXES = {
   tmdb: {
     source: /^https:\/\/image\.tmdb\.org\//,
@@ -50,6 +60,7 @@ export const isRemoteAvatarCacheUrlAllowed = (src: string): boolean => {
         hostname === 'secure.gravatar.com' ||
         hostname === 'www.gravatar.com' ||
         hostname.endsWith('.gravatar.com') ||
+        hostname === 'plex.tv' ||
         hostname.endsWith('.plex.tv'))
     );
   } catch {

--- a/src/utils/imageCache.ts
+++ b/src/utils/imageCache.ts
@@ -2,6 +2,11 @@ export type CacheableImageType = 'tmdb' | 'avatar' | 'tvdb' | 'music' | 'book';
 
 export const AVATAR_FALLBACK_IMAGE = '/user-icon-192x192.png';
 
+export const getInitialImageUrl = (
+  type: CacheableImageType,
+  imageUrl: string
+): string => (type === 'avatar' ? AVATAR_FALLBACK_IMAGE : imageUrl);
+
 export const getImageErrorFallback = (
   type: CacheableImageType,
   currentSrc: string


### PR DESCRIPTION
## Description

Separates cheap image-cache hits from bounded upstream cache-miss work, adds cache warming and cache-only lookup support, and improves remote-avatar failure handling. Missing Plex avatars keep the default visible while a background refresh runs instead of blocking the response.

**AI Disclosure:** Codex was used for implementation, rebasing, testing, and preparation of this pull request.

## How Has This Been Tested?

- 34 focused image proxy, avatar proxy, remote-avatar cache, and client image-cache tests pass.
- TypeScript typechecking passes.
- ESLint and Prettier checks pass on changed files.

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are needed for these reliability fixes.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no translation keys changed)
- [x] Database migration (not required)