### PR TITLE
fix(network): retry and diagnose transient upstream failures

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -2,6 +2,10 @@ import type { PlexDevice } from '@server/interfaces/api/plexInterfaces';
 import cacheManager from '@server/lib/cache';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import {
+  getHttpErrorDetails,
+  withTransientHttpRetry,
+} from '@server/utils/httpError';
 import { randomUUID } from 'node:crypto';
 import xml2js from 'xml2js';
 import ExternalAPI from './externalapi';
@@ -290,18 +294,27 @@ class PlexTvAPI extends ExternalAPI {
         this.authToken
       );
 
-      const response = await this.axios.get<WatchlistResponse>(
-        '/library/sections/watchlist/all',
+      const response = await withTransientHttpRetry(
+        () =>
+          this.axios.get<WatchlistResponse>('/library/sections/watchlist/all', {
+            params: {
+              'X-Plex-Container-Start': offset,
+              'X-Plex-Container-Size': size,
+            },
+            headers: {
+              'If-None-Match': cachedWatchlist?.etag,
+            },
+            baseURL: 'https://discover.provider.plex.tv',
+            validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
+          }),
         {
-          params: {
-            'X-Plex-Container-Start': offset,
-            'X-Plex-Container-Size': size,
+          onRetry: (error, nextAttempt) => {
+            logger.warn('Retrying transient Plex watchlist request', {
+              label: 'Plex.TV Metadata API',
+              nextAttempt,
+              ...getHttpErrorDetails(error),
+            });
           },
-          headers: {
-            'If-None-Match': cachedWatchlist?.etag,
-          },
-          baseURL: 'https://discover.provider.plex.tv',
-          validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
         }
       );
 
@@ -385,10 +398,10 @@ class PlexTvAPI extends ExternalAPI {
         totalSize: cachedWatchlist?.response.MediaContainer.totalSize ?? 0,
         items: filteredList,
       };
-    } catch (e) {
+    } catch (error) {
       logger.error('Failed to retrieve watchlist items', {
         label: 'Plex.TV Metadata API',
-        errorMessage: e.message,
+        ...getHttpErrorDetails(error),
       });
       return {
         offset,

--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -1,5 +1,9 @@
 import logger from '@server/logger';
 import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
+import {
+  getHttpErrorDetails,
+  withTransientHttpRetry,
+} from '@server/utils/httpError';
 import axios, { type AxiosInstance } from 'axios';
 import rateLimit, { type rateLimitOptions } from 'axios-rate-limit';
 import { createHash } from 'crypto';
@@ -582,11 +586,25 @@ class ImageProxy {
   ): Promise<ImageResponse | null> {
     try {
       const directory = resolveCachePath(this.key, cacheKey);
-      const response = await this.axios.get(path, {
-        responseType: 'arraybuffer',
-        maxContentLength: MAX_IMAGE_BYTES,
-        maxBodyLength: MAX_IMAGE_BYTES,
-      });
+      const response = await withTransientHttpRetry(
+        () =>
+          this.axios.get(path, {
+            responseType: 'arraybuffer',
+            maxContentLength: MAX_IMAGE_BYTES,
+            maxBodyLength: MAX_IMAGE_BYTES,
+          }),
+        {
+          onRetry: (error, nextAttempt) => {
+            logger.debug('Retrying transient upstream image request', {
+              label: 'Image Cache',
+              imageProvider: this.key,
+              imagePath: path,
+              nextAttempt,
+              ...getHttpErrorDetails(error),
+            });
+          },
+        }
+      );
 
       let buffer = Buffer.from(response.data, 'binary');
       if (buffer.length > MAX_IMAGE_BYTES) {
@@ -659,10 +677,12 @@ class ImageProxy {
           ? { imageBuffer: buffer }
           : { filePath }),
       };
-    } catch (e) {
-      logger.debug('Something went wrong caching image.', {
+    } catch (error) {
+      logger.warn('Failed to cache upstream image', {
         label: 'Image Cache',
-        errorMessage: e.message,
+        imageProvider: this.key,
+        imagePath: path,
+        ...getHttpErrorDetails(error),
       });
       return null;
     }

--- a/server/utils/httpError.test.ts
+++ b/server/utils/httpError.test.ts
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  getHttpErrorDetails,
+  isTransientHttpError,
+  withTransientHttpRetry,
+} from './httpError';
+
+describe('HTTP error utilities', () => {
+  it('retains Axios status and error code', () => {
+    const error = new axios.AxiosError(
+      'upstream unavailable',
+      'ECONNRESET',
+      undefined,
+      undefined,
+      {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: {},
+        config: { headers: {} } as never,
+        data: undefined,
+      }
+    );
+
+    assert.deepEqual(getHttpErrorDetails(error), {
+      errorMessage: 'upstream unavailable',
+      errorCode: 'ECONNRESET',
+      status: 503,
+    });
+    assert.equal(isTransientHttpError(error), true);
+  });
+
+  it('does not retry permanent client errors', async () => {
+    const error = new axios.AxiosError(
+      'not found',
+      undefined,
+      undefined,
+      undefined,
+      {
+        status: 404,
+        statusText: 'Not Found',
+        headers: {},
+        config: { headers: {} } as never,
+        data: undefined,
+      }
+    );
+    let attempts = 0;
+
+    await assert.rejects(
+      withTransientHttpRetry(
+        async () => {
+          attempts += 1;
+          throw error;
+        },
+        { maxAttempts: 3, delayMs: 0 }
+      ),
+      error
+    );
+    assert.equal(attempts, 1);
+  });
+
+  it('retries a transient failure once', async () => {
+    const error = new axios.AxiosError('socket reset', 'ECONNRESET');
+    let attempts = 0;
+
+    const result = await withTransientHttpRetry(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw error;
+        }
+        return 'ok';
+      },
+      { delayMs: 0 }
+    );
+
+    assert.equal(result, 'ok');
+    assert.equal(attempts, 2);
+  });
+});

--- a/server/utils/httpError.ts
+++ b/server/utils/httpError.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+
+export type HttpErrorDetails = {
+  errorMessage: string;
+  errorCode?: string;
+  status?: number;
+};
+
+export const getHttpErrorDetails = (error: unknown): HttpErrorDetails => {
+  if (axios.isAxiosError(error)) {
+    return {
+      errorMessage: error.message || error.name || 'Unknown HTTP error',
+      ...(error.code ? { errorCode: error.code } : {}),
+      ...(error.response?.status ? { status: error.response.status } : {}),
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      errorMessage: error.message || error.name || 'Unknown error',
+    };
+  }
+
+  return {
+    errorMessage: String(error || 'Unknown error'),
+  };
+};
+
+export const isTransientHttpError = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+
+  const status = error.response?.status;
+
+  return (
+    status === undefined || status === 408 || status === 429 || status >= 500
+  );
+};
+
+export const withTransientHttpRetry = async <T>(
+  request: () => Promise<T>,
+  {
+    maxAttempts = 2,
+    delayMs = 250,
+    onRetry,
+  }: {
+    maxAttempts?: number;
+    delayMs?: number;
+    onRetry?: (error: unknown, nextAttempt: number) => void;
+  } = {}
+): Promise<T> => {
+  let attempt = 1;
+
+  while (true) {
+    try {
+      return await request();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isTransientHttpError(error)) {
+        throw error;
+      }
+
+      attempt += 1;
+      onRetry?.(error, attempt);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+};


### PR DESCRIPTION
## Description

Adds bounded retries for transient Plex and image-provider failures and normalizes upstream HTTP/network error details for actionable logs. Existing timeout, redirect, and response-size limits remain in effect during retries.

**AI Disclosure:** Codex was used for implementation, rebasing, testing, and preparation of this pull request.

## How Has This Been Tested?

- 13 focused HTTP-error and image-proxy tests pass.
- TypeScript typechecking passes.
- ESLint and Prettier checks pass on changed files.

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are needed for this reliability fix.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no translation keys changed)
- [x] Database migration (not required)