### PR TITLE
fix(requests): allow default added sort

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -367,6 +367,21 @@ describe('PUT /request/:requestId (movie)', () => {
 });
 
 describe('GET /request', () => {
+  it('accepts the default added sort used by the request list', async () => {
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.get('/request').query({
+      filter: 'pending',
+      mediaType: 'all',
+      take: 10,
+      sort: 'added',
+      sortDirection: 'desc',
+      skip: 0,
+    });
+
+    assert.strictEqual(res.status, 200);
+    assert.ok(Array.isArray(res.body.results));
+  });
+
   it('accepts the recent requests slider query', async () => {
     const agent = await loginAs('admin@seerr.dev', 'test1234');
     const res = await agent.get('/request').query({

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -77,7 +77,7 @@ const requestStatusFilters = [
   'available',
   'deleted',
 ] as const;
-const requestSortFields = ['modified'] as const;
+const requestSortFields = ['added', 'modified'] as const;
 const requestSortDirections = ['asc', 'desc'] as const;
 
 const getErrorLogFields = (error: unknown) => ({


### PR DESCRIPTION
## Description

Allows the added sort field used by the default request-list query while retaining the existing sort-direction validation. Route coverage verifies the default pending-request query.

**AI Disclosure:** Codex was used for implementation, rebasing, testing, and preparation of this pull request.

## How Has This Been Tested?

- All 64 request-route tests pass.
- TypeScript typechecking passes.
- ESLint and Prettier checks pass on changed files.

## Screenshots / Logs (if applicable)

Not applicable.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. No documentation changes are needed for this validation fix.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no translation keys changed)
- [x] Database migration (not required)