### PR TITLE
fix(search): preserve result navigation and service availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,13 @@ jobs:
         shell: sh
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          echo "LOCK_HASH=$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ env.LOCK_HASH }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -36,6 +36,8 @@ export interface PublicSettingsResponse {
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
+  musicEnabled: boolean;
+  booksEnabled: boolean;
   discoverRegion: string;
   streamingRegion: string;
   originalLanguage: string;

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -245,6 +245,8 @@ interface FullPublicSettings extends PublicSettings {
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
+  musicEnabled: boolean;
+  booksEnabled: boolean;
   discoverRegion: string;
   streamingRegion: string;
   originalLanguage: string;
@@ -972,6 +974,8 @@ class Settings {
       series4kEnabled: this.data.sonarr.some(
         (sonarr) => sonarr.is4k && sonarr.isDefault
       ),
+      musicEnabled: this.data.lidarr.length > 0,
+      booksEnabled: this.data.readarr.length > 0,
       discoverRegion: this.data.main.discoverRegion,
       streamingRegion: this.data.main.streamingRegion,
       originalLanguage: this.data.main.originalLanguage,

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { afterEach, before, describe, it, mock } from 'node:test';
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 
 import ExternalAPI from '@server/api/externalapi';
 import MusicBrainz from '@server/api/musicbrainz';
@@ -14,7 +14,11 @@ import MediaIdentifier, {
 } from '@server/entity/MediaIdentifier';
 import MetadataAlbum from '@server/entity/MetadataAlbum';
 import MetadataArtist from '@server/entity/MetadataArtist';
-import { getSettings } from '@server/lib/settings';
+import {
+  getSettings,
+  type LidarrSettings,
+  type ReadarrSettings,
+} from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
 import { setupTestDb } from '@server/test/db';
 import type { Express } from 'express';
@@ -90,8 +94,15 @@ before(async () => {
   app = createApp();
 });
 
+beforeEach(() => {
+  getSettings().lidarr = [{} as LidarrSettings];
+  getSettings().readarr = [{} as ReadarrSettings];
+});
+
 afterEach(() => {
   mock.restoreAll();
+  getSettings().lidarr = [];
+  getSettings().readarr = [];
 });
 
 setupTestDb();
@@ -123,6 +134,40 @@ async function loginAs(email: string, password: string) {
 }
 
 describe('GET /search', () => {
+  it('omits optional catalog providers without configured services', async () => {
+    const settings = getSettings();
+    const priorLidarr = settings.lidarr;
+    const priorReadarr = settings.readarr;
+    settings.lidarr = [];
+    settings.readarr = [];
+
+    const albumSearch = mock.method(MusicBrainz.prototype, 'searchAlbum');
+    const artistSearch = mock.method(MusicBrainz.prototype, 'searchArtist');
+    const bookSearch = mock.method(OpenLibraryAPI.prototype, 'searchBooks');
+    mockPrivate(ExternalAPI.prototype, 'get', async (endpoint) => {
+      if (endpoint === '/search/multi') {
+        return { page: 1, total_pages: 1, total_results: 0, results: [] };
+      }
+
+      throw new Error(`Unexpected endpoint: ${String(endpoint)}`);
+    });
+
+    try {
+      const agent = await loginAs('friend@seerr.dev', 'test1234');
+      const res = await agent.get('/search').query({ query: 'optional' });
+
+      assert.strictEqual(res.status, 200);
+      assert.deepStrictEqual(res.body.results, []);
+      assert.strictEqual(res.body.totalResults, 0);
+      assert.strictEqual(albumSearch.mock.callCount(), 0);
+      assert.strictEqual(artistSearch.mock.callCount(), 0);
+      assert.strictEqual(bookSearch.mock.callCount(), 0);
+    } finally {
+      settings.lidarr = priorLidarr;
+      settings.readarr = priorReadarr;
+    }
+  });
+
   it('rejects missing search queries before provider lookup', async () => {
     const agent = await loginAs('friend@seerr.dev', 'test1234');
     const res = await agent.get('/search');

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -19,6 +19,7 @@ import {
   findSearchProvider,
   type CombinedSearchResponse,
 } from '@server/lib/search';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { mapOpenLibrarySearchDoc } from '@server/models/Book';
 import { mapSearchResults } from '@server/models/Search';
@@ -153,6 +154,27 @@ searchRoutes.get('/', async (req, res, next) => {
     return res.status(400).json({ status: 400, message: parsedType.error });
   }
   const typeFilter = parsedType.value;
+  const settings = getSettings();
+  const musicEnabled = settings.lidarr.length > 0;
+  const booksEnabled = settings.readarr.length > 0;
+
+  if ((typeFilter === 'album' || typeFilter === 'artist') && !musicEnabled) {
+    return res.status(200).json({
+      page,
+      totalPages: 1,
+      totalResults: 0,
+      results: [],
+    });
+  }
+
+  if (typeFilter === 'book' && !booksEnabled) {
+    return res.status(200).json({
+      page,
+      totalPages: 1,
+      totalResults: 0,
+      results: [],
+    });
+  }
 
   try {
     const searchProvider = findSearchProvider(queryString.toLowerCase());
@@ -181,21 +203,27 @@ searchRoutes.get('/', async (req, res, next) => {
           page,
           language,
         }),
-        musicbrainz.searchAlbum({
-          query: queryString,
-          limit: 20,
-          offset: musicOffset,
-        }),
-        musicbrainz.searchArtist({
-          query: queryString,
-          limit: 20,
-          offset: musicOffset,
-        }),
-        openLibrary.searchBooks({
-          query: queryString,
-          page,
-          limit: 20,
-        }),
+        musicEnabled
+          ? musicbrainz.searchAlbum({
+              query: queryString,
+              limit: 20,
+              offset: musicOffset,
+            })
+          : Promise.resolve([]),
+        musicEnabled
+          ? musicbrainz.searchArtist({
+              query: queryString,
+              limit: 20,
+              offset: musicOffset,
+            })
+          : Promise.resolve([]),
+        booksEnabled
+          ? openLibrary.searchBooks({
+              query: queryString,
+              page,
+              limit: 20,
+            })
+          : Promise.resolve({ numFound: 0, start: 0, docs: [] }),
       ]);
 
       const rawTmdbResults =
@@ -520,16 +548,30 @@ searchRoutes.get('/', async (req, res, next) => {
 
     const mappedResults = await mapSearchResults(results.results, media);
 
+    const capabilityResults = mappedResults.filter(
+      (result) =>
+        !('mediaType' in result) ||
+        (((result.mediaType !== 'album' && result.mediaType !== 'artist') ||
+          musicEnabled) &&
+          (result.mediaType !== 'book' || booksEnabled))
+    );
+
     const filteredResults = typeFilter
-      ? mappedResults.filter(
+      ? capabilityResults.filter(
           (result) => 'mediaType' in result && result.mediaType === typeFilter
         )
-      : mappedResults;
+      : capabilityResults;
+
+    const capabilityFiltered =
+      capabilityResults.length !== mappedResults.length;
 
     return res.status(200).json({
       page: results.page,
       totalPages: results.total_pages,
-      totalResults: typeFilter ? filteredResults.length : results.total_results,
+      totalResults:
+        typeFilter || capabilityFiltered
+          ? filteredResults.length
+          : results.total_results,
       results: filteredResults,
     });
   } catch (e) {

--- a/server/subscriber/MediaSubscriber.test.ts
+++ b/server/subscriber/MediaSubscriber.test.ts
@@ -68,7 +68,8 @@ describe('MediaSubscriber', () => {
     const observedBatchSizes: number[] = [];
     let readIndex = 0;
     const requestRepository = {
-      maximum: async () => MEDIA_SUBSCRIBER_REQUEST_BATCH_SIZE + 2,
+      findOne: async () =>
+        new MediaRequest({ id: MEDIA_SUBSCRIBER_REQUEST_BATCH_SIZE + 2 }),
       find: async (options: { take: number }) => {
         observedLimits.push(options.take);
         if (readIndex === 0) {

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -25,7 +25,13 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
     callback: (requests: MediaRequest[]) => Promise<void>
   ): Promise<void> {
     const requestRepository = manager.getRepository(MediaRequest);
-    const maxId = await requestRepository.maximum('id', where);
+    const newestRequest = await requestRepository.findOne({
+      where,
+      select: { id: true },
+      order: { id: 'DESC' },
+      relationLoadStrategy: 'query',
+    });
+    const maxId = newestRequest?.id;
     if (!Number.isSafeInteger(maxId) || !maxId || maxId <= 0) {
       return;
     }

--- a/src/components/Layout/MobileMenu/index.tsx
+++ b/src/components/Layout/MobileMenu/index.tsx
@@ -1,7 +1,9 @@
 import Badge from '@app/components/Common/Badge';
 import { menuMessages } from '@app/components/Layout/Sidebar';
 import useClickOutside from '@app/hooks/useClickOutside';
+import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
+import { isOptionalCatalogPathEnabled } from '@app/utils/serviceAvailability';
 import { Transition } from '@headlessui/react';
 import {
   BookOpenIcon,
@@ -73,6 +75,7 @@ const MobileMenu = ({
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState(false);
   const { hasPermission } = useUser();
+  const { currentSettings } = useSettings();
   const router = useRouter();
   useClickOutside(ref, () => {
     if (closeTimer.current !== undefined) {
@@ -190,12 +193,13 @@ const MobileMenu = ({
     () =>
       menuLinks.filter(
         (link) =>
-          !link.requiredPermission ||
-          hasPermission(link.requiredPermission, {
-            type: link.permissionType ?? 'and',
-          })
+          isOptionalCatalogPathEnabled(link.href, currentSettings) &&
+          (!link.requiredPermission ||
+            hasPermission(link.requiredPermission, {
+              type: link.permissionType ?? 'and',
+            }))
       ),
-    [hasPermission, menuLinks]
+    [currentSettings, hasPermission, menuLinks]
   );
 
   useEffect(() => {

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -1,8 +1,10 @@
 import Badge from '@app/components/Common/Badge';
 import VersionStatus from '@app/components/Layout/VersionStatus';
 import useClickOutside from '@app/hooks/useClickOutside';
+import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
+import { isOptionalCatalogPathEnabled } from '@app/utils/serviceAvailability';
 import versionedAsset from '@app/utils/versionedAsset';
 import { Transition } from '@headlessui/react';
 import {
@@ -147,7 +149,18 @@ const Sidebar = ({
   const router = useRouter();
   const intl = useIntl();
   const { hasPermission } = useUser();
+  const { currentSettings } = useSettings();
   useClickOutside(navRef, () => setClosed());
+
+  const visibleSidebarLinks = SidebarLinks.filter(
+    (link) =>
+      isOptionalCatalogPathEnabled(link.href, currentSettings) &&
+      (link.requiredPermission
+        ? hasPermission(link.requiredPermission, {
+            type: link.permissionType ?? 'and',
+          })
+        : true)
+  );
 
   useEffect(() => {
     if (openIssuesCount) {
@@ -219,13 +232,7 @@ const Sidebar = ({
                       </span>
                     </div>
                     <nav className="mt-10 flex-1 space-y-4 px-4">
-                      {SidebarLinks.filter((link) =>
-                        link.requiredPermission
-                          ? hasPermission(link.requiredPermission, {
-                              type: link.permissionType ?? 'and',
-                            })
-                          : true
-                      ).map((sidebarLink) => {
+                      {visibleSidebarLinks.map((sidebarLink) => {
                         return (
                           <Link
                             key={`mobile-${sidebarLink.messagesKey}`}
@@ -289,13 +296,7 @@ const Sidebar = ({
                 </span>
               </div>
               <nav className="mt-8 flex-1 space-y-4 px-4">
-                {SidebarLinks.filter((link) =>
-                  link.requiredPermission
-                    ? hasPermission(link.requiredPermission, {
-                        type: link.permissionType ?? 'and',
-                      })
-                    : true
-                ).map((sidebarLink) => {
+                {visibleSidebarLinks.map((sidebarLink) => {
                   return (
                     <Link
                       key={`desktop-${sidebarLink.messagesKey}`}

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -19,6 +19,8 @@ const defaultSettings: PublicSettingsResponse = {
   mediaServerLogin: true,
   movie4kEnabled: false,
   series4kEnabled: false,
+  musicEnabled: false,
+  booksEnabled: false,
   discoverRegion: '',
   streamingRegion: '',
   originalLanguage: '',

--- a/src/hooks/useSearchInput.test.ts
+++ b/src/hooks/useSearchInput.test.ts
@@ -72,21 +72,32 @@ describe('getSearchQuery', () => {
 describe('shouldNavigateToSearch', () => {
   it('does not navigate again when the URL already has the search query', () => {
     strictEqual(
-      shouldNavigateToSearch('/search', 'alien', 'alien', true),
+      shouldNavigateToSearch('/search', 'alien', 'alien', true, false),
       false
     );
   });
 
   it('navigates when a new debounced query is ready', () => {
     strictEqual(
-      shouldNavigateToSearch('/search', 'alien', 'aliens', true),
+      shouldNavigateToSearch('/search', 'alien', 'aliens', true, false),
       true
     );
   });
 
   it('does not navigate for a closed or empty search', () => {
-    strictEqual(shouldNavigateToSearch('/', '', 'alien', false), false);
-    strictEqual(shouldNavigateToSearch('/', '', '', true), false);
+    strictEqual(shouldNavigateToSearch('/', '', 'alien', false, true), false);
+    strictEqual(shouldNavigateToSearch('/', '', '', true, true), false);
+  });
+
+  it('navigates when search was opened on the current non-search route', () => {
+    strictEqual(shouldNavigateToSearch('/', '', 'alien', true, true), true);
+  });
+
+  it('does not reopen search after navigating from a result to details', () => {
+    strictEqual(
+      shouldNavigateToSearch('/movie/[movieId]', '', 'alien', true, false),
+      false
+    );
   });
 });
 
@@ -116,6 +127,65 @@ describe('shouldSyncSearchInput', () => {
 });
 
 describe('useSearchInput routing', () => {
+  it('leaves a clicked search result on top and preserves search in history', async () => {
+    dom = new JSDOM('<div id="root"></div>', {
+      url: 'http://localhost/search?query=alien',
+    });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: dom.window,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: dom.window.document,
+    });
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    const pushes: unknown[] = [];
+    let routeChangeStart: (() => void) | undefined;
+    const router = createRouter({
+      events: {
+        emit: () => undefined,
+        off: (event, handler) => {
+          if (event === 'routeChangeStart' && routeChangeStart === handler) {
+            routeChangeStart = undefined;
+          }
+        },
+        on: (event, handler) => {
+          if (event === 'routeChangeStart') {
+            routeChangeStart = handler;
+          }
+        },
+      },
+      push: async (...args) => {
+        pushes.push(args);
+        return true;
+      },
+    });
+    const Probe = () => {
+      useSearchInput();
+      return null;
+    };
+    const render = () =>
+      root?.render(
+        createElement(RouterProvider, { router }, createElement(Probe))
+      );
+
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () => render());
+
+    routeChangeStart?.();
+    router.pathname = '/movie/[movieId]';
+    router.route = '/movie/[movieId]';
+    router.asPath = '/movie/348';
+    router.query = { movieId: '348' };
+    await act(async () => render());
+
+    strictEqual(pushes.length, 0);
+  });
+
   it('preserves newer typing through a stale route update and navigates once', async () => {
     dom = new JSDOM('<div id="root"></div>', {
       url: 'http://localhost/search',

--- a/src/hooks/useSearchInput.ts
+++ b/src/hooks/useSearchInput.ts
@@ -14,21 +14,39 @@ type Url = string | UrlObject;
 interface SearchObject {
   searchValue: string;
   searchOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setIsOpen: (isOpen: boolean) => void;
   setSearchValue: Dispatch<SetStateAction<string>>;
   clear: () => void;
 }
 
 const useSearchInput = (): SearchObject => {
   const router = useRouter();
-  const [searchOpen, setIsOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [lastRoute, setLastRoute] = useState<Url | null>(null);
   const pendingSearchQuery = useRef<string | null>(null);
+  const searchOpenedOnCurrentRoute = useRef(false);
   const closingSearch = useRef(false);
   const [searchValue, debouncedValue, setSearchValue] = useDebouncedState(
     getSearchQuery(router.query.query)
   );
   const routeQuery = getSearchQuery(router.query.query);
+
+  const setIsOpen = useCallback((isOpen: boolean) => {
+    searchOpenedOnCurrentRoute.current = isOpen;
+    setSearchOpen(isOpen);
+  }, []);
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      searchOpenedOnCurrentRoute.current = false;
+    };
+
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+    };
+  }, [router.events]);
 
   /**
    * This effect handles routing when the debounced search input
@@ -43,7 +61,8 @@ const useSearchInput = (): SearchObject => {
         router.pathname,
         routeQuery,
         debouncedValue,
-        searchOpen
+        searchOpen,
+        searchOpenedOnCurrentRoute.current
       ) &&
       pendingSearchQuery.current !== debouncedValue
     ) {
@@ -132,12 +151,13 @@ const useSearchInput = (): SearchObject => {
       setSearchValue(routeQuery);
 
       if (!router.pathname.startsWith('/search') && !routeQuery) {
-        setIsOpen(false);
+        searchOpenedOnCurrentRoute.current = false;
+        setSearchOpen(false);
       }
     }
 
     if (router.pathname.startsWith('/search') && !closingSearch.current) {
-      setIsOpen(true);
+      setSearchOpen(true);
     }
   }, [
     debouncedValue,
@@ -151,7 +171,8 @@ const useSearchInput = (): SearchObject => {
   const clear = useCallback(() => {
     closingSearch.current = true;
     pendingSearchQuery.current = null;
-    setIsOpen(false);
+    searchOpenedOnCurrentRoute.current = false;
+    setSearchOpen(false);
     setSearchValue('');
   }, [setSearchValue]);
 
@@ -163,7 +184,7 @@ const useSearchInput = (): SearchObject => {
       setSearchValue,
       clear,
     }),
-    [clear, searchOpen, searchValue, setSearchValue]
+    [clear, searchOpen, searchValue, setIsOpen, setSearchValue]
   );
 };
 

--- a/src/hooks/useSearchInput.utils.ts
+++ b/src/hooks/useSearchInput.utils.ts
@@ -5,11 +5,14 @@ export const shouldNavigateToSearch = (
   pathname: string,
   currentQuery: string,
   nextQuery: string,
-  searchOpen: boolean
+  searchOpen: boolean,
+  searchOpenedOnCurrentRoute: boolean
 ): boolean =>
   searchOpen &&
   nextQuery !== '' &&
-  (!pathname.startsWith('/search') || currentQuery !== nextQuery);
+  (pathname.startsWith('/search')
+    ? currentQuery !== nextQuery
+    : searchOpenedOnCurrentRoute);
 
 export const shouldSyncSearchInput = (
   pathname: string,

--- a/src/utils/serviceAvailability.test.ts
+++ b/src/utils/serviceAvailability.test.ts
@@ -1,0 +1,39 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import { isOptionalCatalogPathEnabled } from './serviceAvailability';
+
+describe('isOptionalCatalogPathEnabled', () => {
+  it('hides optional catalogs without a configured backend service', () => {
+    const availability = { musicEnabled: false, booksEnabled: false };
+
+    strictEqual(
+      isOptionalCatalogPathEnabled('/discover/music', availability),
+      false
+    );
+    strictEqual(
+      isOptionalCatalogPathEnabled('/discover/books', availability),
+      false
+    );
+    strictEqual(
+      isOptionalCatalogPathEnabled('/discover/movies', availability),
+      true
+    );
+  });
+
+  it('shows each optional catalog when its backend is configured', () => {
+    strictEqual(
+      isOptionalCatalogPathEnabled('/discover/music', {
+        musicEnabled: true,
+        booksEnabled: false,
+      }),
+      true
+    );
+    strictEqual(
+      isOptionalCatalogPathEnabled('/discover/books', {
+        musicEnabled: false,
+        booksEnabled: true,
+      }),
+      true
+    );
+  });
+});

--- a/src/utils/serviceAvailability.ts
+++ b/src/utils/serviceAvailability.ts
@@ -1,0 +1,12 @@
+export interface OptionalServiceAvailability {
+  musicEnabled: boolean;
+  booksEnabled: boolean;
+}
+
+export const isOptionalCatalogPathEnabled = (
+  path: string,
+  availability: OptionalServiceAvailability
+): boolean =>
+  path !== '/discover/music'
+    ? path !== '/discover/books' || availability.booksEnabled
+    : availability.musicEnabled;


### PR DESCRIPTION
## Description
This removes the left side for non-configured services and removes them from search

## How Has This Been Tested?
Deployed to my k8s instance and verified working

## Screenshots / Logs (if applicable)
<img width="250" height="437" alt="image" src="https://github.com/user-attachments/assets/81f8750b-b489-43f2-9500-f10dcfb19d60" />
<img width="1261" height="830" alt="image" src="https://github.com/user-attachments/assets/88745b07-c2df-44fd-835d-efd4edeeb63f" />
<img width="921" height="670" alt="image" src="https://github.com/user-attachments/assets/75387483-ddf2-4fb2-8464-b3600c6ec306" />
<img width="886" height="647" alt="image" src="https://github.com/user-attachments/assets/00f49a35-8c23-486d-bbb2-b58845b8cdd6" />




## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
