### PR TITLE
fix(requests): retry failed book dispatches

### DIFF
--- a/server/migration/postgres/1783200000000-RequeueFailedBookRequests.ts
+++ b/server/migration/postgres/1783200000000-RequeueFailedBookRequests.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RequeueFailedBookRequests1783200000000 implements MigrationInterface {
+  name = 'RequeueFailedBookRequests1783200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO "request_dispatch_outbox" ("requestId", "attempts", "nextAttemptAt") SELECT "id", 0, now() FROM "media_request" WHERE "type" = 'book' AND "status" = 4 ON CONFLICT ("requestId") DO NOTHING`
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Seeded dispatch records may have accumulated retry state by rollback time.
+    // Removing them would discard valid pending work, so rollback is intentionally
+    // non-destructive.
+  }
+}

--- a/server/migration/sqlite/1783200000000-RequeueFailedBookRequests.test.ts
+++ b/server/migration/sqlite/1783200000000-RequeueFailedBookRequests.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DataSource } from 'typeorm';
+import { RequeueFailedBookRequests1783200000000 } from './1783200000000-RequeueFailedBookRequests';
+
+test('SQLite failed book request migration seeds only missing failed books', async () => {
+  const dataSource = await new DataSource({
+    type: 'sqlite',
+    database: ':memory:',
+  }).initialize();
+  const queryRunner = dataSource.createQueryRunner();
+  const migration = new RequeueFailedBookRequests1783200000000();
+
+  try {
+    await queryRunner.query(
+      `CREATE TABLE "media_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "type" varchar NOT NULL, "status" integer NOT NULL)`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "request_dispatch_outbox" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "requestId" integer NOT NULL UNIQUE, "attempts" integer NOT NULL DEFAULT (0), "nextAttemptAt" datetime)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "media_request" ("id", "type", "status") VALUES (1, 'book', 4), (2, 'book', 2), (3, 'movie', 4), (4, 'book', 4)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "request_dispatch_outbox" ("requestId", "attempts") VALUES (4, 7)`
+    );
+
+    await migration.up(queryRunner);
+
+    assert.deepEqual(
+      await queryRunner.query(
+        `SELECT "requestId", "attempts" FROM "request_dispatch_outbox" ORDER BY "requestId"`
+      ),
+      [
+        { requestId: 1, attempts: 0 },
+        { requestId: 4, attempts: 7 },
+      ]
+    );
+  } finally {
+    await queryRunner.release();
+    await dataSource.destroy();
+  }
+});

--- a/server/migration/sqlite/1783200000000-RequeueFailedBookRequests.ts
+++ b/server/migration/sqlite/1783200000000-RequeueFailedBookRequests.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RequeueFailedBookRequests1783200000000 implements MigrationInterface {
+  name = 'RequeueFailedBookRequests1783200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT OR IGNORE INTO "request_dispatch_outbox" ("requestId", "attempts", "nextAttemptAt") SELECT "id", 0, CURRENT_TIMESTAMP FROM "media_request" WHERE "type" = 'book' AND "status" = 4`
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Seeded dispatch records may have accumulated retry state by rollback time.
+    // Removing them would discard valid pending work, so rollback is intentionally
+    // non-destructive.
+  }
+}

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -79,6 +79,7 @@ const READARR_APPROVED_RETRY_BATCH_SIZE = 1;
 const READARR_MIN_PROVIDER_RETRY_DELAY_MS = 1_000;
 const READARR_MAX_PROVIDER_RETRY_DELAY_MS = 3_600_000;
 const READARR_MAX_RECONCILIATION_BATCH_SIZE = 100;
+export const READARR_FAILED_RETRY_DELAY_MS = 6 * 60 * 60 * 1_000;
 export const READARR_MAX_LOOKUP_RESULTS = 50;
 export const READARR_LOOKUP_HYDRATION_CONCURRENCY = 5;
 const activeReadarrDispatches = new Map<number, Promise<number | undefined>>();
@@ -546,7 +547,14 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         const request = await getRepository(MediaRequest).findOne({
           where: { id: requestId },
         });
-        if (!request || request.status !== MediaRequestStatus.APPROVED) {
+        const isRetryableFailedBook =
+          request?.type === MediaType.BOOK &&
+          request.status === MediaRequestStatus.FAILED;
+        if (
+          !request ||
+          (request.status !== MediaRequestStatus.APPROVED &&
+            !isRetryableFailedBook)
+        ) {
           return { delivered: true };
         }
 
@@ -1407,7 +1415,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       return;
     }
 
-    if (entity.status !== MediaRequestStatus.APPROVED) {
+    if (
+      entity.status !== MediaRequestStatus.APPROVED &&
+      entity.status !== MediaRequestStatus.FAILED
+    ) {
       return;
     }
 
@@ -1937,29 +1948,38 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         return this.getReadarrDispatchRetryDelay(entity, e);
       }
 
+      const wasAlreadyFailed = entity.status === MediaRequestStatus.FAILED;
       const requestRepository = getRepository(MediaRequest);
       const mediaRepository = getRepository(Media);
       const media = await mediaRepository.findOne({
         where: { id: entity.media.id },
       });
 
-      entity.status = MediaRequestStatus.FAILED;
-      await requestRepository.save(entity);
+      if (!wasAlreadyFailed) {
+        entity.status = MediaRequestStatus.FAILED;
+        await requestRepository.save(entity);
+      }
 
-      logger.warn('Something went wrong sending book request to Bookshelf', {
-        label: 'Media Request',
-        requestId: entity.id,
-        mediaId: entity.media.id,
-        errorMessage: e instanceof Error ? e.message : String(e),
-      });
+      logger.warn(
+        'Something went wrong sending book request to Bookshelf; retaining the failed request in the durable dispatch queue.',
+        {
+          label: 'Media Request',
+          requestId: entity.id,
+          mediaId: entity.media.id,
+          retryAfterMs: READARR_FAILED_RETRY_DELAY_MS,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
+      );
 
-      if (media) {
+      if (media && !wasAlreadyFailed) {
         await MediaRequest.sendNotification(
           entity,
           media,
           Notification.MEDIA_FAILED
         );
       }
+
+      return READARR_FAILED_RETRY_DELAY_MS;
     }
   }
 

--- a/server/test/MediaRequestSubscriber.test.ts
+++ b/server/test/MediaRequestSubscriber.test.ts
@@ -36,6 +36,7 @@ import { runWithServarrServiceMutationAdmission } from '@server/lib/serviceAdmis
 import { getSettings } from '@server/lib/settings';
 import {
   MediaRequestSubscriber,
+  READARR_FAILED_RETRY_DELAY_MS,
   READARR_LOOKUP_HYDRATION_CONCURRENCY,
   READARR_MAX_LOOKUP_RESULTS,
   clampReadarrProviderRetryDelay,
@@ -1101,13 +1102,23 @@ describe('MediaRequestSubscriber service dispatch', () => {
 
     mock.method(notificationManager, 'sendNotification', () => undefined);
 
-    await new MediaRequestSubscriber().sendToReadarr(request);
+    const subscriber = new MediaRequestSubscriber();
+    const retryAfterMs = await subscriber.sendToReadarr(request);
 
     assert.equal(addBook.mock.callCount(), 0);
-    const savedRequest = await getRepository(MediaRequest).findOneByOrFail({
-      id: request.id,
+    const savedRequest = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: request.id },
+      relations: { media: true, requestedBy: true },
     });
     assert.equal(savedRequest.status, MediaRequestStatus.FAILED);
+    assert.equal(retryAfterMs, READARR_FAILED_RETRY_DELAY_MS);
+
+    const failedRetry = await subscriber.dispatchRequestById(savedRequest.id);
+    assert.deepEqual(failedRetry, {
+      delivered: false,
+      retryAfterMs: READARR_FAILED_RETRY_DELAY_MS,
+    });
+    assert.equal(addBook.mock.callCount(), 0);
   });
 
   it('resolves no-ISBN translated OpenLibrary works through Wikidata canonical title terms', async () => {


### PR DESCRIPTION
## Description

Tired of having to retry failed download, this is also challenging architecture choice should this be here or in bookshelf.

## How Has This Been Tested?
Local k8s deployment, this has the least testing of all PRs.

## Screenshots / Logs (if applicable)
<img width="1248" height="83" alt="image" src="https://github.com/user-attachments/assets/90fa3c04-02f6-426e-a14f-0e663200735b" />


## Checklist

- [ x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [ x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [ x] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
- [ x] Successful build `pnpm build`
- [ x] Translation keys `pnpm i18n:extract`
- [ x] Database migration (if required)
