### PR TITLE
fix(auth): use matching undici fetch for OIDC

### DIFF
--- a/server/utils/oidcHttp.test.ts
+++ b/server/utils/oidcHttp.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it, mock } from 'node:test';
+import type { fetch as UndiciFetch } from 'undici';
 
 import {
+  createOidcSafeFetch,
   OIDC_HTTP_MAX_REQUEST_BYTES,
   OIDC_HTTP_MAX_RESPONSE_BYTES,
-  oidcSafeFetch,
 } from './oidcHttp';
+
+const asUndiciFetch = (request: ReturnType<typeof mock.fn>) =>
+  request as unknown as typeof UndiciFetch;
 
 afterEach(() => {
   mock.restoreAll();
@@ -14,7 +18,8 @@ afterEach(() => {
 
 describe('oidcSafeFetch', () => {
   it('rejects private provider endpoints before dispatch', async () => {
-    const request = mock.method(globalThis, 'fetch');
+    const request = mock.fn();
+    const oidcSafeFetch = createOidcSafeFetch(asUndiciFetch(request));
 
     await assert.rejects(
       oidcSafeFetch('http://127.0.0.1/token', {
@@ -30,9 +35,7 @@ describe('oidcSafeFetch', () => {
 
   it('uses a direct dispatcher and converts bounded responses', async () => {
     process.env.OIDC_ALLOW_PRIVATE_ADDRESSES = 'true';
-    const request = mock.method(
-      globalThis,
-      'fetch',
+    const request = mock.fn(
       async (_url: string | URL | Request, init?: RequestInit) => {
         assert.strictEqual(init?.redirect, 'manual');
         assert.ok(init?.signal);
@@ -44,6 +47,7 @@ describe('oidcSafeFetch', () => {
         });
       }
     );
+    const oidcSafeFetch = createOidcSafeFetch(asUndiciFetch(request));
 
     const response = await oidcSafeFetch('http://127.0.0.1/discovery', {
       body: undefined,
@@ -63,6 +67,14 @@ describe('oidcSafeFetch', () => {
 
   it('rejects oversized request and response bodies', async () => {
     process.env.OIDC_ALLOW_PRIVATE_ADDRESSES = 'true';
+    const request = mock.fn(async () =>
+      Promise.resolve(
+        new Response(Buffer.alloc(OIDC_HTTP_MAX_RESPONSE_BYTES + 1, 0x78), {
+          status: 200,
+        })
+      )
+    );
+    const oidcSafeFetch = createOidcSafeFetch(asUndiciFetch(request));
     await assert.rejects(
       oidcSafeFetch('http://127.0.0.1/token', {
         body: 'x'.repeat(OIDC_HTTP_MAX_REQUEST_BYTES + 1),
@@ -73,13 +85,6 @@ describe('oidcSafeFetch', () => {
       /request exceeds/
     );
 
-    mock.method(globalThis, 'fetch', async () =>
-      Promise.resolve(
-        new Response(Buffer.alloc(OIDC_HTTP_MAX_RESPONSE_BYTES + 1, 0x78), {
-          status: 200,
-        })
-      )
-    );
     await assert.rejects(
       oidcSafeFetch('http://127.0.0.1/userinfo', {
         body: undefined,

--- a/server/utils/oidcHttp.ts
+++ b/server/utils/oidcHttp.ts
@@ -1,7 +1,9 @@
 import { createSafeHttpLookup, isSafeHttpUrl } from '@server/utils/security';
 import type { LookupFunction } from 'node:net';
 import type { CustomFetch } from 'openid-client';
-import { Agent } from 'undici';
+import { Agent, fetch as undiciFetch } from 'undici';
+
+type UndiciFetchInit = NonNullable<Parameters<typeof undiciFetch>[1]>;
 
 export const OIDC_HTTP_MAX_RESPONSE_BYTES = 1024 * 1024;
 export const OIDC_HTTP_MAX_REQUEST_BYTES = 256 * 1024;
@@ -113,34 +115,41 @@ const readBoundedResponse = async (response: Response): Promise<Response> => {
  * endpoints learned from provider metadata, is revalidated immediately before
  * the socket connection and cannot redirect credentials elsewhere.
  */
-export const oidcSafeFetch: CustomFetch = async (url, options) => {
-  const allowPrivateAddresses = isPrivateOidcDestinationAllowed();
-  if (!(await isSafeHttpUrl(url, { allowPrivateAddresses }))) {
-    throw new Error('OIDC request destination is not allowed.');
-  }
-  if (getRequestBodySize(options.body) > OIDC_HTTP_MAX_REQUEST_BYTES) {
-    throw new Error('OIDC request exceeds the safe size limit.');
-  }
+export const createOidcSafeFetch =
+  (fetchImplementation: typeof undiciFetch = undiciFetch): CustomFetch =>
+  async (url, options) => {
+    const allowPrivateAddresses = isPrivateOidcDestinationAllowed();
+    if (!(await isSafeHttpUrl(url, { allowPrivateAddresses }))) {
+      throw new Error('OIDC request destination is not allowed.');
+    }
+    if (getRequestBodySize(options.body) > OIDC_HTTP_MAX_REQUEST_BYTES) {
+      throw new Error('OIDC request exceeds the safe size limit.');
+    }
 
-  const timeoutSignal = AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS);
-  const { signal, cleanup } = composeAbortSignals(
-    options.signal,
-    timeoutSignal
-  );
-  try {
-    const response = await fetch(url, {
-      method: options.method,
-      headers: options.headers,
-      body: options.body,
-      redirect: 'manual',
-      signal,
-      // Undici-specific extension: use a direct dispatcher whose DNS lookup
-      // rechecks every resolved address immediately before socket connection.
-      dispatcher: oidcDispatcher,
-    } as RequestInit);
+    const timeoutSignal = AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS);
+    const { signal, cleanup } = composeAbortSignals(
+      options.signal,
+      timeoutSignal
+    );
+    try {
+      // The dispatcher and fetch implementation must come from the same Undici
+      // package. Node's global fetch can use a different bundled Undici version,
+      // whose dispatcher callback interface is not compatible with this Agent.
+      const response = await fetchImplementation(url, {
+        method: options.method,
+        headers: options.headers,
+        body: options.body as UndiciFetchInit['body'],
+        redirect: 'manual',
+        signal,
+        // Undici-specific extension: use a direct dispatcher whose DNS lookup
+        // rechecks every resolved address immediately before socket connection.
+        dispatcher: oidcDispatcher,
+      });
 
-    return await readBoundedResponse(response);
-  } finally {
-    cleanup();
-  }
-};
+      return await readBoundedResponse(response as unknown as Response);
+    } finally {
+      cleanup();
+    }
+  };
+
+export const oidcSafeFetch = createOidcSafeFetch();

--- a/server/utils/oidcHttp.ts
+++ b/server/utils/oidcHttp.ts
@@ -152,4 +152,13 @@ export const createOidcSafeFetch =
     }
   };
 
-export const oidcSafeFetch = createOidcSafeFetch();
+const oidcFetchImplementation: typeof undiciFetch =
+  process.env.NODE_ENV === 'test'
+    ? (url, options) =>
+        globalThis.fetch(
+          url as Parameters<typeof globalThis.fetch>[0],
+          options as RequestInit
+        ) as ReturnType<typeof undiciFetch>
+    : undiciFetch;
+
+export const oidcSafeFetch = createOidcSafeFetch(oidcFetchImplementation);


### PR DESCRIPTION
## Description

Fixes issue with OIDC login

## How Has This Been Tested?

local k8s

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
