### PR TITLE
fix(ui): deduplicate repeated toasts

### DIFF
--- a/src/hooks/useToasts.test.ts
+++ b/src/hooks/useToasts.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getToastDedupeId } from './useToasts';
+
+describe('getToastDedupeId', () => {
+  it('deduplicates identical string messages by appearance', () => {
+    assert.strictEqual(
+      getToastDedupeId('Something went wrong. Please try again.', 'error'),
+      getToastDedupeId('Something went wrong. Please try again.', 'error')
+    );
+    assert.notStrictEqual(
+      getToastDedupeId('Something went wrong. Please try again.', 'error'),
+      getToastDedupeId('Something went wrong. Please try again.', 'warning')
+    );
+  });
+
+  it('leaves rendered message nodes independently addressable', () => {
+    assert.strictEqual(getToastDedupeId(null, 'error'), undefined);
+  });
+});

--- a/src/hooks/useToasts.tsx
+++ b/src/hooks/useToasts.tsx
@@ -7,6 +7,12 @@ interface ToastOptions {
   autoDismiss?: boolean;
 }
 
+export const getToastDedupeId = (
+  message: React.ReactNode,
+  appearance: ToastOptions['appearance'] = 'info'
+): string | undefined =>
+  typeof message === 'string' ? `${appearance}:${message}` : undefined;
+
 export const useToasts = () => {
   const addToast = useCallback(
     (
@@ -30,6 +36,7 @@ export const useToasts = () => {
         },
         {
           duration: options?.autoDismiss !== false ? 4000 : Infinity,
+          id: getToastDedupeId(message, options?.appearance),
         }
       );
 


### PR DESCRIPTION
## Description
Resolves issue where toast notifications are sent multiple times

## How Has This Been Tested?

local k8s

## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
