### PR TITLE
fix(logging): accept legacy managed log symlink

### DIFF
--- a/server/lib/logFileSecurity.test.ts
+++ b/server/lib/logFileSecurity.test.ts
@@ -100,6 +100,23 @@ describe('log file permissions', () => {
     assert.equal((await fs.stat(datedLog)).mode & 0o777, PRIVATE_LOG_FILE_MODE);
   });
 
+  it('allows the legacy Overseerr logger-managed symlink', async () => {
+    const logDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'seerr-logs-')
+    );
+    temporaryDirectories.push(logDirectory);
+    const datedLog = path.join(logDirectory, 'overseerr-2026-07-15.log');
+    await fs.writeFile(datedLog, 'log', { mode: 0o644 });
+    await fs.symlink(
+      path.basename(datedLog),
+      path.join(logDirectory, 'overseerr.log')
+    );
+
+    secureLogDirectory(logDirectory);
+
+    assert.equal((await fs.stat(datedLog)).mode & 0o777, PRIVATE_LOG_FILE_MODE);
+  });
+
   it('rejects escaping and unexpected log symlinks', async () => {
     const parent = await fs.mkdtemp(path.join(os.tmpdir(), 'seerr-logs-'));
     temporaryDirectories.push(parent);

--- a/server/lib/logFileSecurity.ts
+++ b/server/lib/logFileSecurity.ts
@@ -4,7 +4,11 @@ import { assertNoSymlinkDirectoryComponents } from './pathSecurity';
 
 export const PRIVATE_LOG_DIRECTORY_MODE = 0o700;
 export const PRIVATE_LOG_FILE_MODE = 0o600;
-const MANAGED_LOG_SYMLINKS = new Set(['seerr.log', '.machinelogs.json']);
+const MANAGED_LOG_SYMLINKS = new Set([
+  'seerr.log',
+  'overseerr.log',
+  '.machinelogs.json',
+]);
 
 const assertManagedLogSymlink = (directory: string, file: string): void => {
   if (!MANAGED_LOG_SYMLINKS.has(file)) {


### PR DESCRIPTION
## Description
fixes issue with legacy log file names

## How Has This Been Tested?
local k8s

## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
