### PR TITLE
fix(scanners): repair orphaned book identifiers

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -498,14 +498,29 @@ class BaseScanner<T> {
                   relations: { media: true },
                   order: { id: 'ASC' },
                 });
+                const orphanedIdentifiers = existingIdentifiers.filter(
+                  (identifier) => !identifier.media
+                );
+
+                if (orphanedIdentifiers.length > 0) {
+                  await identifierRepository.remove(orphanedIdentifiers);
+                  this.log(
+                    `Removed ${orphanedIdentifiers.length} orphaned identifier(s) while processing book: ${title}`,
+                    'warn'
+                  );
+                }
+
+                const linkedIdentifiers = existingIdentifiers.filter(
+                  (identifier) => !!identifier.media
+                );
                 const existingIdentifier =
-                  existingIdentifiers.find(
+                  linkedIdentifiers.find(
                     (identifier) =>
                       identifier.provider === provider &&
                       identifier.value === normalizedValue &&
                       identifier.media.mediaType === MediaType.BOOK
                   ) ??
-                  existingIdentifiers.find(
+                  linkedIdentifiers.find(
                     (identifier) =>
                       identifier.media.mediaType === MediaType.BOOK
                   );
@@ -622,10 +637,11 @@ class BaseScanner<T> {
                     )
                       .filter(
                         (identifier) =>
-                          identifier.media.id !== existing.id ||
-                          candidateKeys.has(
-                            `${identifier.provider}:${identifier.value}`
-                          )
+                          !!identifier.media &&
+                          (identifier.media.id !== existing.id ||
+                            candidateKeys.has(
+                              `${identifier.provider}:${identifier.value}`
+                            ))
                       )
                       .map(
                         (identifier) =>

--- a/server/lib/scanners/readarr/readarr.test.ts
+++ b/server/lib/scanners/readarr/readarr.test.ts
@@ -66,6 +66,20 @@ function configureReadarr(overrides: Partial<ReadarrSettings>[] = [{}]): void {
     serviceType: 'ebook',
     ...o,
   })) as ReadarrSettings[];
+  process.env.SEERR_EXTERNAL_CONFIG = JSON.stringify({
+    vapidPublic: settings.vapidPublic,
+    vapidPrivate: settings.vapidPrivate,
+    main: settings.main,
+    plex: settings.plex,
+    jellyfin: settings.jellyfin,
+    oidc: settings.oidc,
+    tautulli: settings.tautulli,
+    radarr: settings.radarr,
+    sonarr: settings.sonarr,
+    lidarr: settings.lidarr,
+    readarr: settings.readarr,
+    notifications: settings.notifications,
+  });
 }
 
 function fakeReadarrBook(overrides: Partial<ReadarrBook> = {}): ReadarrBook {
@@ -362,6 +376,36 @@ describe('Readarr Scanner', () => {
     });
 
     assert.strictEqual(getEditionsCallCount, 1);
+    assert.strictEqual(identifiers.length, 1);
+    assert.strictEqual(identifiers[0].media.mediaType, MediaType.BOOK);
+  });
+
+  it('replaces an orphaned identifier instead of failing the book scan', async () => {
+    await getRepository(MediaIdentifier).save(
+      new MediaIdentifier({
+        provider: MediaIdentifierProvider.READARR,
+        value: 'orphaned-readarr-book',
+        canonical: false,
+      })
+    );
+    configureReadarr([{ syncEnabled: true }]);
+    getBooksImpl = async () => [
+      fakeReadarrBook({
+        foreignBookId: 'orphaned-readarr-book',
+        editions: [],
+      }),
+    ];
+
+    await readarrScanner.run();
+
+    const identifiers = await getRepository(MediaIdentifier).find({
+      where: {
+        provider: MediaIdentifierProvider.READARR,
+        value: 'orphaned-readarr-book',
+      },
+      relations: { media: true },
+    });
+
     assert.strictEqual(identifiers.length, 1);
     assert.strictEqual(identifiers[0].media.mediaType, MediaType.BOOK);
   });

--- a/server/lib/scanners/readarr/readarr.test.ts
+++ b/server/lib/scanners/readarr/readarr.test.ts
@@ -66,20 +66,6 @@ function configureReadarr(overrides: Partial<ReadarrSettings>[] = [{}]): void {
     serviceType: 'ebook',
     ...o,
   })) as ReadarrSettings[];
-  process.env.SEERR_EXTERNAL_CONFIG = JSON.stringify({
-    vapidPublic: settings.vapidPublic,
-    vapidPrivate: settings.vapidPrivate,
-    main: settings.main,
-    plex: settings.plex,
-    jellyfin: settings.jellyfin,
-    oidc: settings.oidc,
-    tautulli: settings.tautulli,
-    radarr: settings.radarr,
-    sonarr: settings.sonarr,
-    lidarr: settings.lidarr,
-    readarr: settings.readarr,
-    notifications: settings.notifications,
-  });
 }
 
 function fakeReadarrBook(overrides: Partial<ReadarrBook> = {}): ReadarrBook {


### PR DESCRIPTION
## Description
Fixes minor issue of book identifiers missing from bookshelf

## How Has This Been Tested?
local k8s

## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
