### PR TITLE
fix(helm): align chart with v3.8.0

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -5,7 +5,7 @@ description: SeerrNG Helm chart for Kubernetes
 type: application
 version: 1.0.2
 # renovate: image=ghcr.io/snapetech/seerrng
-appVersion: 'v3.7.16'
+appVersion: 'v3.8.0'
 maintainers:
   - name: Snapetech
     url: https://github.com/snapetech

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.16](https://img.shields.io/badge/AppVersion-v3.7.16-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.8.0](https://img.shields.io/badge/AppVersion-v3.8.0-informational?style=flat-square)
 
 SeerrNG Helm chart for Kubernetes
 


### PR DESCRIPTION
## Summary

- update the Helm chart appVersion from v3.7.16 to the current v3.8.0 release
- update the generated chart README badge
- restore the chart release security invariant checked in CI

## Verification

- `node --test scripts/check-helm-security.test.mjs` (7/7)
- Prettier check
- `git diff --check`