### PR TITLE
fix(sqlite): restore request fields after quota migration

### DIFF
--- a/server/migration/sqlite/1783300000000-RestoreMediaRequestRoutingFields.test.ts
+++ b/server/migration/sqlite/1783300000000-RestoreMediaRequestRoutingFields.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DataSource } from 'typeorm';
+import { RestoreMediaRequestRoutingFields1783300000000 } from './1783300000000-RestoreMediaRequestRoutingFields';
+
+test('SQLite media-request routing-field repair is reversible', async () => {
+  const dataSource = await new DataSource({
+    type: 'sqlite',
+    database: ':memory:',
+  }).initialize();
+  const queryRunner = dataSource.createQueryRunner();
+  const migration = new RestoreMediaRequestRoutingFields1783300000000();
+
+  try {
+    await queryRunner.query(
+      'CREATE TABLE "media_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "ignoreQuota" boolean NOT NULL DEFAULT (0))'
+    );
+    await queryRunner.query(
+      'INSERT INTO "media_request" ("ignoreQuota") VALUES (1)'
+    );
+
+    await migration.up(queryRunner);
+
+    const repairedColumns = (await queryRunner.query(
+      'PRAGMA table_info("media_request")'
+    )) as { name: string }[];
+    assert.deepStrictEqual(
+      repairedColumns.map((column) => column.name),
+      ['id', 'ignoreQuota', 'bookFormat', 'metadataProfileId']
+    );
+    assert.deepStrictEqual(
+      await queryRunner.query(
+        'SELECT "ignoreQuota", "bookFormat", "metadataProfileId" FROM "media_request"'
+      ),
+      [{ ignoreQuota: 1, bookFormat: null, metadataProfileId: null }]
+    );
+
+    await migration.down(queryRunner);
+    const remainingColumns = (await queryRunner.query(
+      'PRAGMA table_info("media_request")'
+    )) as { name: string }[];
+    assert.deepStrictEqual(
+      remainingColumns.map((column) => column.name),
+      ['id', 'ignoreQuota']
+    );
+    assert.deepStrictEqual(
+      await queryRunner.query(
+        'SELECT "id", "ignoreQuota" FROM "media_request"'
+      ),
+      [{ id: 1, ignoreQuota: 1 }]
+    );
+  } finally {
+    await queryRunner.release();
+    await dataSource.destroy();
+  }
+});

--- a/server/migration/sqlite/1783300000000-RestoreMediaRequestRoutingFields.ts
+++ b/server/migration/sqlite/1783300000000-RestoreMediaRequestRoutingFields.ts
@@ -1,0 +1,31 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RestoreMediaRequestRoutingFields1783300000000 implements MigrationInterface {
+  name = 'RestoreMediaRequestRoutingFields1783300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasColumn('media_request', 'bookFormat'))) {
+      await queryRunner.query(
+        `ALTER TABLE "media_request" ADD "bookFormat" varchar`
+      );
+    }
+    if (!(await queryRunner.hasColumn('media_request', 'metadataProfileId'))) {
+      await queryRunner.query(
+        `ALTER TABLE "media_request" ADD "metadataProfileId" integer`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (await queryRunner.hasColumn('media_request', 'metadataProfileId')) {
+      await queryRunner.query(
+        `ALTER TABLE "media_request" DROP COLUMN "metadataProfileId"`
+      );
+    }
+    if (await queryRunner.hasColumn('media_request', 'bookFormat')) {
+      await queryRunner.query(
+        `ALTER TABLE "media_request" DROP COLUMN "bookFormat"`
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a forward SQLite migration that restores `bookFormat` and `metadataProfileId` after the ignore-quota table rebuild dropped them
- preserve existing request rows and `ignoreQuota` values
- add focused reversible migration coverage

## Root cause

`1781732036510-AddIgnoreQuotaToMediaRequest` reconstructs `media_request` from a pre-books schema, silently omitting both newer columns. Fresh migration replays then produce request list/count 500s and break user deletion in Cypress.

## Verification

- focused migration test: pass
- server typecheck: pass
- full Cypress database preparation with migrations: `bookFormat`, `metadataProfileId`, and `ignoreQuota` all present
- repair migration recorded in the SQLite migrations table

The shipped migration is intentionally left unchanged; this is a forward repair for already-upgraded databases.