### PR TITLE
fix(settings): revalidate qualified status cache key

### DIFF
--- a/cypress/e2e/settings/general-settings.cy.ts
+++ b/cypress/e2e/settings/general-settings.cy.ts
@@ -14,7 +14,10 @@ describe('General Settings', () => {
 
   it('modifies setting that requires restart', () => {
     cy.intercept('POST', '/api/v1/settings/network').as('saveNetwork');
-    cy.intercept('GET', '/api/v1/status').as('getStatus');
+    cy.intercept(
+      'GET',
+      '/api/v1/status?checkUpdateAvailable=false'
+    ).as('getStatus');
     cy.visit('/settings/network');
     cy.wait('@getStatus');
 

--- a/cypress/e2e/settings/general-settings.cy.ts
+++ b/cypress/e2e/settings/general-settings.cy.ts
@@ -14,10 +14,9 @@ describe('General Settings', () => {
 
   it('modifies setting that requires restart', () => {
     cy.intercept('POST', '/api/v1/settings/network').as('saveNetwork');
-    cy.intercept(
-      'GET',
-      '/api/v1/status?checkUpdateAvailable=false'
-    ).as('getStatus');
+    cy.intercept('GET', '/api/v1/status?checkUpdateAvailable=false').as(
+      'getStatus'
+    );
     cy.visit('/settings/network');
     cy.wait('@getStatus');
 

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -211,7 +211,7 @@ const SettingsMain = () => {
                 versionCheck: values?.versionCheck,
               });
               mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate('/api/v1/status?checkUpdateAvailable=false');
 
               if (setLocale) {
                 setLocale(

--- a/src/components/Settings/SettingsNetwork/index.tsx
+++ b/src/components/Settings/SettingsNetwork/index.tsx
@@ -181,7 +181,7 @@ const SettingsNetwork = () => {
                 apiRequestTimeout: Number(values.apiRequestTimeout) * 1000,
               });
               mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate('/api/v1/status?checkUpdateAvailable=false');
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {
                 autoDismiss: true,


### PR DESCRIPTION
## Summary

- revalidate the same query-qualified status cache key used by `StatusChecker`
- restore immediate restart-required feedback after network settings changes
- update the Cypress intercept to cover the actual status request

## Verification

- `pnpm exec eslint cypress/e2e/settings/general-settings.cy.ts src/components/Settings/SettingsMain/index.tsx src/components/Settings/SettingsNetwork/index.tsx`
- `pnpm typecheck`
- `pnpm cypress:build`
- `pnpm exec cypress run --config baseUrl=http://localhost:5056 --spec cypress/e2e/settings/general-settings.cy.ts` (2/2 passing)
