### PR TITLE
ci: allow unit suite completion headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
   unit-test:
     name: Unit Tests
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary

- raise the unit-test job limit from 30 to 45 minutes
- preserve the existing serial test execution required by the singleton application DataSource

The current successful upstream unit runs take approximately 29m30s. Additional valid coverage causes the job to be canceled while tests are still passing, leaving no practical runtime headroom.

## Evidence

- integration run `30757812567` produced continuous passing test output until GitHub canceled it at 30m04s
- recent successful upstream runs `30718440312` and `30718275223` took 29m29s and 29m30s
- `node scripts/check-workflow-boundaries.mjs` passes (27 workflows validated)
- Prettier check passes for `.github/workflows/ci.yml`
