### PR TITLE
fix(auth): allow Plex login over direct HTTP

### DIFF
--- a/release-notes/fixed-plex-http-csrf.md
+++ b/release-notes/fixed-plex-http-csrf.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users, operators
+area: authentication
+action: none
+breaking: false
+---
+Plex sign-in now starts correctly on direct HTTP/LAN deployments while CSRF cookies remain restricted to secure transport on HTTPS deployments.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,3 @@
-import csurf from '@dr.pogodin/csurf';
 import PlexAPI from '@server/api/plexapi';
 import dataSource, {
   enforceSqliteDatabasePermissions,
@@ -34,6 +33,9 @@ import {
   normalizeApiErrorStatus,
 } from '@server/middleware/apiError';
 import clearCookies from '@server/middleware/clearcookies';
+import csrfProtection, {
+  requestUsesSecureTransport,
+} from '@server/middleware/csrfProtection';
 import csrfTokenCookie from '@server/middleware/csrfTokenCookie';
 import securityHeaders from '@server/middleware/securityHeaders';
 import routes from '@server/routes';
@@ -286,18 +288,8 @@ app
       })
     );
     if (settings.network.csrfProtection) {
-      server.use(
-        csurf({
-          cookie: {
-            httpOnly: true,
-            sameSite: true,
-            secure: true,
-            key: '_csrf',
-            path: '/',
-          },
-        })
-      );
-      server.use(csrfTokenCookie(true));
+      server.use(csrfProtection());
+      server.use(csrfTokenCookie(requestUsesSecureTransport));
     }
 
     // Set up sessions

--- a/server/middleware/csrfProtection.ts
+++ b/server/middleware/csrfProtection.ts
@@ -1,0 +1,37 @@
+import csurf from '@dr.pogodin/csurf';
+import type { Request, RequestHandler } from 'express';
+
+const createCsrfProtection = (secure: boolean): RequestHandler =>
+  csurf({
+    cookie: {
+      httpOnly: true,
+      sameSite: true,
+      secure,
+      key: '_csrf',
+      path: '/',
+    },
+  });
+
+export const requestUsesSecureTransport = (req: Request): boolean => {
+  const forwardedProtocol = req
+    .get('x-forwarded-proto')
+    ?.split(',', 1)[0]
+    .trim()
+    .toLowerCase();
+
+  return req.secure || forwardedProtocol === 'https';
+};
+
+export const csrfProtection = (): RequestHandler => {
+  const httpProtection = createCsrfProtection(false);
+  const httpsProtection = createCsrfProtection(true);
+
+  return (req, res, next) =>
+    (requestUsesSecureTransport(req) ? httpsProtection : httpProtection)(
+      req,
+      res,
+      next
+    );
+};
+
+export default csrfProtection;

--- a/server/middleware/csrfTokenCookie.test.ts
+++ b/server/middleware/csrfTokenCookie.test.ts
@@ -1,9 +1,31 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import cookieParser from 'cookie-parser';
 import express from 'express';
 import request from 'supertest';
+import csrfProtection, { requestUsesSecureTransport } from './csrfProtection';
 import csrfTokenCookie from './csrfTokenCookie';
+
+const getCsrfCookies = (cookies: string[] = []) => ({
+  secret: cookies.find((cookie) => cookie.startsWith('_csrf=')),
+  token: cookies.find((cookie) => cookie.startsWith('XSRF-TOKEN=')),
+});
+
+const getCookieValue = (cookie: string): string =>
+  decodeURIComponent(
+    cookie.slice(cookie.indexOf('=') + 1, cookie.indexOf(';'))
+  );
+
+const createTransportAwareApp = () => {
+  const app = express();
+  app.use(cookieParser());
+  app.use(csrfProtection());
+  app.use(csrfTokenCookie(requestUsesSecureTransport));
+  app.get('/', (_req, res) => res.sendStatus(204));
+  app.post('/', (_req, res) => res.sendStatus(204));
+  return app;
+};
 
 describe('csrfTokenCookie', () => {
   it('makes the browser-readable token available across application routes', async () => {
@@ -24,5 +46,33 @@ describe('csrfTokenCookie', () => {
     assert.match(tokenCookie, /(?:^|;) Path=\/(?:;|$)/);
     assert.match(tokenCookie, /(?:^|;) SameSite=Strict(?:;|$)/);
     assert.doesNotMatch(tokenCookie, /(?:^|;) HttpOnly(?:;|$)/);
+  });
+
+  it('allows both CSRF cookies on direct HTTP deployments', async () => {
+    const agent = request.agent(createTransportAwareApp());
+    const response = await agent.get('/');
+    const cookies = getCsrfCookies(response.get('Set-Cookie'));
+
+    assert.ok(cookies.secret);
+    assert.ok(cookies.token);
+    assert.doesNotMatch(cookies.secret, /(?:^|;) Secure(?:;|$)/);
+    assert.doesNotMatch(cookies.token, /(?:^|;) Secure(?:;|$)/);
+
+    await agent
+      .post('/')
+      .set('X-XSRF-TOKEN', getCookieValue(cookies.token))
+      .expect(204);
+  });
+
+  it('secures both CSRF cookies behind an HTTPS terminator', async () => {
+    const response = await request(createTransportAwareApp())
+      .get('/')
+      .set('X-Forwarded-Proto', 'https');
+    const cookies = getCsrfCookies(response.get('Set-Cookie'));
+
+    assert.ok(cookies.secret);
+    assert.ok(cookies.token);
+    assert.match(cookies.secret, /(?:^|;) Secure(?:;|$)/);
+    assert.match(cookies.token, /(?:^|;) Secure(?:;|$)/);
   });
 });

--- a/server/middleware/csrfTokenCookie.ts
+++ b/server/middleware/csrfTokenCookie.ts
@@ -1,6 +1,8 @@
-import type { RequestHandler } from 'express';
+import type { Request, RequestHandler } from 'express';
 
-export const csrfTokenCookie = (secure: boolean): RequestHandler =>
+type SecureCookiePolicy = boolean | ((req: Request) => boolean);
+
+export const csrfTokenCookie = (secure: SecureCookiePolicy): RequestHandler =>
   function setCsrfTokenCookie(req, res, next) {
     // The browser client reads this cookie to populate X-XSRF-TOKEN. Without
     // an explicit root path, a token issued while rendering a nested page is
@@ -8,7 +10,7 @@ export const csrfTokenCookie = (secure: boolean): RequestHandler =>
     res.cookie('XSRF-TOKEN', req.csrfToken(), {
       path: '/',
       sameSite: true,
-      secure,
+      secure: typeof secure === 'function' ? secure(req) : secure,
     });
     next();
   };


### PR DESCRIPTION
## Description
after i installed SeerrNG on my NAS and went to its webpage, i was able to choose Plex as my server but when i clicked on the login button, a window briefly showed up then closed. I did not get a window where I could login to Plex. I used ChatGPT to help me diagnose the problem, she found that SeerrNG issued the CSRF cookie with the secure flag which was not being returned by the browser over HTTP. the fix we came up with correctly selects the cookie policy depending on HTTP/HTTPS connection. https and https-terminating proxies continue to receive secure cookies.

## How Has This Been Tested?
with the help of chatgpt we:
- focused CSRF tested with 3 tests
- prettier, eslint and server type check passed on my windows laptop
- manual tests were done on my asustor nas using direct http
- the plex login was presented correctly in both a normal browser tab as well incogneto.
- when running the full test suite on my windows laptop, there were unrelated environment specific failures.


## Screenshots / Logs (if applicable)
no screenshots were made

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [ ] The fragment includes audience, area, action, and breaking-change status.
- [ ] I previewed the release text with `pnpm release-notes:preview`.
we did add and validate the required metadata, however did not run the release note preview command.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
AI Disclosure:
- i used chatgpt to help me investigate and find a fix for the problem i was having.
- chatgpt assisted with the designing, writing the code and writing regression tests.
- chatgpt helped guide me through debugging, validation and preparing the contribution.
- i personally observed the behavior, performed the tests and manually verified, several times, this fix on my nas.