### PR TITLE
fix(discover): restore list scroll position

### DIFF
--- a/release-notes/fixed-discovery-scroll-restoration.md
+++ b/release-notes/fixed-discovery-scroll-restoration.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users
+area: discovery
+action: none
+breaking: false
+---
+Movie, series, and book discovery lists now return to the previous scroll position after viewing an item's details.

--- a/src/components/Discover/DiscoverBooks/index.tsx
+++ b/src/components/Discover/DiscoverBooks/index.tsx
@@ -8,6 +8,7 @@ import {
   countLibraryFilters,
 } from '@app/components/Discover/LibraryFilterSlideover/filterUtils';
 import useDiscover from '@app/hooks/useDiscover';
+import useDiscoverScrollRestoration from '@app/hooks/useDiscoverScrollRestoration';
 import { useBatchUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import defineMessages from '@app/utils/defineMessages';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
@@ -68,6 +69,13 @@ const DiscoverBooks = () => {
     query ? { query, sortBy } : subject ? { subject, sortBy } : { sortBy },
     { randomizeOrder: sortBy === 'ranked' }
   );
+  useDiscoverScrollRestoration({
+    mediaType: 'book',
+    itemCount: titles.length,
+    isLoading: isLoadingInitialData || isLoadingMore,
+    isReachingEnd,
+    fetchMore,
+  });
 
   return (
     <>

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -9,6 +9,7 @@ import {
   prepareFilterValues,
 } from '@app/components/Discover/constants';
 import useDiscover from '@app/hooks/useDiscover';
+import useDiscoverScrollRestoration from '@app/hooks/useDiscoverScrollRestoration';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
 import defineMessages from '@app/utils/defineMessages';
@@ -70,6 +71,13 @@ const DiscoverMovies = () => {
     preparedFilters,
     { randomizeOrder: !preparedFilters.sortBy }
   );
+  useDiscoverScrollRestoration({
+    mediaType: 'movie',
+    itemCount: titles.length,
+    isLoading: isLoadingInitialData || isLoadingMore,
+    isReachingEnd,
+    fetchMore,
+  });
   const [showFilters, setShowFilters] = useState(false);
 
   if (error) {

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -9,6 +9,7 @@ import {
   prepareFilterValues,
 } from '@app/components/Discover/constants';
 import useDiscover from '@app/hooks/useDiscover';
+import useDiscoverScrollRestoration from '@app/hooks/useDiscoverScrollRestoration';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
 import defineMessages from '@app/utils/defineMessages';
@@ -72,6 +73,13 @@ const DiscoverTv = () => {
     },
     { randomizeOrder: !preparedFilters.sortBy }
   );
+  useDiscoverScrollRestoration({
+    mediaType: 'tv',
+    itemCount: titles.length,
+    isLoading: isLoadingInitialData || isLoadingMore,
+    isReachingEnd,
+    fetchMore,
+  });
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/hooks/useDiscoverScrollRestoration.ts
+++ b/src/hooks/useDiscoverScrollRestoration.ts
@@ -1,0 +1,119 @@
+import type { RestorableDiscoverMediaType } from '@app/utils/discoverScrollRestoration';
+import {
+  DISCOVER_SCROLL_HISTORY_KEY,
+  getDiscoverScrollEntry,
+  getScrollRestorationAction,
+  isMediaDetailPath,
+} from '@app/utils/discoverScrollRestoration';
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
+
+type UseDiscoverScrollRestorationOptions = {
+  mediaType: RestorableDiscoverMediaType;
+  itemCount: number;
+  isLoading: boolean;
+  isReachingEnd: boolean;
+  fetchMore: () => void;
+};
+
+const useDiscoverScrollRestoration = ({
+  mediaType,
+  itemCount,
+  isLoading,
+  isReachingEnd,
+  fetchMore,
+}: UseDiscoverScrollRestorationOptions): void => {
+  const router = useRouter();
+  const itemCountRef = useRef(itemCount);
+  const loadRequestedRef = useRef(false);
+  const [entry, setEntry] = useState(() =>
+    typeof window === 'undefined'
+      ? undefined
+      : getDiscoverScrollEntry(window.history.state, router.asPath)
+  );
+
+  itemCountRef.current = itemCount;
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    setEntry(getDiscoverScrollEntry(window.history.state, router.asPath));
+  }, [router.asPath, router.isReady]);
+
+  useEffect(() => {
+    const saveScrollPosition = (url: string) => {
+      if (!isMediaDetailPath(url, mediaType)) {
+        return;
+      }
+
+      const currentState =
+        window.history.state && typeof window.history.state === 'object'
+          ? window.history.state
+          : {};
+
+      window.history.replaceState(
+        {
+          ...currentState,
+          [DISCOVER_SCROLL_HISTORY_KEY]: {
+            path: router.asPath,
+            scrollY: window.scrollY,
+            itemCount: itemCountRef.current,
+          },
+        },
+        '',
+        window.location.href
+      );
+    };
+
+    router.events.on('routeChangeStart', saveScrollPosition);
+
+    return () => router.events.off('routeChangeStart', saveScrollPosition);
+  }, [mediaType, router.asPath, router.events]);
+
+  useEffect(() => {
+    if (isLoading) {
+      loadRequestedRef.current = false;
+      return;
+    }
+
+    const action = getScrollRestorationAction({
+      entry,
+      itemCount,
+      isLoading,
+      isReachingEnd,
+    });
+
+    if (action === 'load-more') {
+      if (!loadRequestedRef.current) {
+        loadRequestedRef.current = true;
+        fetchMore();
+      }
+
+      return;
+    }
+
+    if (action !== 'restore' || !entry) {
+      return;
+    }
+
+    const currentState =
+      window.history.state && typeof window.history.state === 'object'
+        ? { ...window.history.state }
+        : {};
+    delete currentState[DISCOVER_SCROLL_HISTORY_KEY];
+    window.history.replaceState(currentState, '', window.location.href);
+
+    const firstFrame = window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        window.scrollTo({ top: entry.scrollY, left: 0, behavior: 'auto' });
+        setEntry(undefined);
+      });
+    });
+
+    return () => window.cancelAnimationFrame(firstFrame);
+  }, [entry, fetchMore, isLoading, isReachingEnd, itemCount]);
+};
+
+export default useDiscoverScrollRestoration;

--- a/src/utils/discoverScrollRestoration.test.ts
+++ b/src/utils/discoverScrollRestoration.test.ts
@@ -1,0 +1,72 @@
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  DISCOVER_SCROLL_HISTORY_KEY,
+  getDiscoverScrollEntry,
+  getScrollRestorationAction,
+  isMediaDetailPath,
+} from './discoverScrollRestoration';
+
+describe('discover scroll restoration', () => {
+  const entry = {
+    path: '/discover/movies?sortBy=popularity.desc',
+    scrollY: 4200,
+    itemCount: 80,
+  };
+
+  it('recognizes only the corresponding media detail route', () => {
+    strictEqual(isMediaDetailPath('/movie/123', 'movie'), true);
+    strictEqual(isMediaDetailPath('/tv/123', 'movie'), false);
+    strictEqual(isMediaDetailPath('/book/OL123W?from=list', 'book'), true);
+    strictEqual(isMediaDetailPath('/discover/books', 'book'), false);
+  });
+
+  it('reads valid restoration data only for the matching history entry', () => {
+    const state = { [DISCOVER_SCROLL_HISTORY_KEY]: entry };
+
+    deepStrictEqual(getDiscoverScrollEntry(state, entry.path), entry);
+    strictEqual(getDiscoverScrollEntry(state, '/discover/movies'), undefined);
+    strictEqual(
+      getDiscoverScrollEntry(
+        {
+          [DISCOVER_SCROLL_HISTORY_KEY]: {
+            ...entry,
+            scrollY: Number.NaN,
+          },
+        },
+        entry.path
+      ),
+      undefined
+    );
+  });
+
+  it('loads enough infinite-scroll results before restoring the offset', () => {
+    strictEqual(
+      getScrollRestorationAction({
+        entry,
+        itemCount: 20,
+        isLoading: false,
+        isReachingEnd: false,
+      }),
+      'load-more'
+    );
+    strictEqual(
+      getScrollRestorationAction({
+        entry,
+        itemCount: 20,
+        isLoading: true,
+        isReachingEnd: false,
+      }),
+      'none'
+    );
+    strictEqual(
+      getScrollRestorationAction({
+        entry,
+        itemCount: 80,
+        isLoading: false,
+        isReachingEnd: false,
+      }),
+      'restore'
+    );
+  });
+});

--- a/src/utils/discoverScrollRestoration.ts
+++ b/src/utils/discoverScrollRestoration.ts
@@ -1,0 +1,79 @@
+export type RestorableDiscoverMediaType = 'movie' | 'tv' | 'book';
+
+export type DiscoverScrollEntry = {
+  path: string;
+  scrollY: number;
+  itemCount: number;
+};
+
+export const DISCOVER_SCROLL_HISTORY_KEY = '__seerrDiscoverScroll';
+
+const detailPathPatterns: Record<RestorableDiscoverMediaType, RegExp> = {
+  movie: /^\/movie\/[^/?#]+(?:[/?#]|$)/,
+  tv: /^\/tv\/[^/?#]+(?:[/?#]|$)/,
+  book: /^\/book\/[^/?#]+(?:[/?#]|$)/,
+};
+
+export const isMediaDetailPath = (
+  url: string,
+  mediaType: RestorableDiscoverMediaType
+): boolean => {
+  const path = url.startsWith('http') ? new URL(url).pathname : url;
+
+  return detailPathPatterns[mediaType].test(path);
+};
+
+export const getDiscoverScrollEntry = (
+  historyState: unknown,
+  path: string
+): DiscoverScrollEntry | undefined => {
+  if (!historyState || typeof historyState !== 'object') {
+    return undefined;
+  }
+
+  const entry = (historyState as Record<string, unknown>)[
+    DISCOVER_SCROLL_HISTORY_KEY
+  ];
+
+  if (!entry || typeof entry !== 'object') {
+    return undefined;
+  }
+
+  const candidate = entry as Partial<DiscoverScrollEntry>;
+
+  if (
+    candidate.path !== path ||
+    typeof candidate.scrollY !== 'number' ||
+    !Number.isFinite(candidate.scrollY) ||
+    candidate.scrollY < 0 ||
+    typeof candidate.itemCount !== 'number' ||
+    !Number.isInteger(candidate.itemCount) ||
+    candidate.itemCount < 0
+  ) {
+    return undefined;
+  }
+
+  return candidate as DiscoverScrollEntry;
+};
+
+export const getScrollRestorationAction = ({
+  entry,
+  itemCount,
+  isLoading,
+  isReachingEnd,
+}: {
+  entry?: DiscoverScrollEntry;
+  itemCount: number;
+  isLoading: boolean;
+  isReachingEnd: boolean;
+}): 'none' | 'load-more' | 'restore' => {
+  if (!entry) {
+    return 'none';
+  }
+
+  if (itemCount >= entry.itemCount || isReachingEnd) {
+    return 'restore';
+  }
+
+  return isLoading ? 'none' : 'load-more';
+};


### PR DESCRIPTION
## Description

Ability to go back to scroll location after clicking into item.

Written with AI. Evidence by AI.

## How Has This Been Tested?

- `pnpm test src/utils/discoverScrollRestoration.test.ts` — 3 passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm test` — 1,684 passed, 31 failed because macOS resolves temporary paths through the `/var` symlink; the remaining blocklist failure passed when rerun in isolation

## Screenshots / Logs (if applicable)

Not applicable.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [ ] The fragment includes audience, area, action, and breaking-change status.
- [ ] I previewed the release text with `pnpm release-notes:preview`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
