### PR TITLE
fix(ci): restore baseline pull request checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   validate-main-tag:
     name: Validate main release tag
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -43,6 +44,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == 'push' && "$GITHUB_REF_TYPE" != 'tag' ]]; then
+            echo 'Release pushes must originate from a tag.' >&2
+            exit 1
+          fi
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9][0-9A-Za-z._+-]{0,126}$ ]]; then
             echo 'Invalid release tag.' >&2
             exit 1

--- a/deploy/install-bookshelf-backend.test.mjs
+++ b/deploy/install-bookshelf-backend.test.mjs
@@ -285,14 +285,8 @@ describe('Bookshelf backup permissions', () => {
     );
     assert.match(env, /BOOKSHELF_EBOOKS_PORT=9787/);
     assert.match(env, /BOOKSHELF_AUDIOBOOKS_PORT=9788/);
-    assert.match(
-      compose,
-      /BOOKSHELF_EBOOKS_PORT:-8787.*\/ping/s
-    );
-    assert.match(
-      compose,
-      /BOOKSHELF_AUDIOBOOKS_PORT:-8788.*\/ping/s
-    );
+    assert.match(compose, /BOOKSHELF_EBOOKS_PORT:-8787.*\/ping/s);
+    assert.match(compose, /BOOKSHELF_AUDIOBOOKS_PORT:-8788.*\/ping/s);
     assert.match(
       await readFile(
         path.join(environment.BOOKSHELF_EBOOKS_CONFIG_DIR, 'config.xml'),

--- a/release-notes/fixed-release-workflow-admission.md
+++ b/release-notes/fixed-release-workflow-admission.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: operators
+area: release-pipeline
+action: none
+breaking: false
+---
+Release retries now require dispatching from `main`, and tag-triggered releases reject non-tag refs before privileged publishing begins.

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -24,13 +24,27 @@ test('release package channels wait for the reusable release asset build', () =>
 
   assert.equal(assetBuild.uses, './.github/workflows/release-assets.yml');
   assert.equal(assetBuild.needs, 'publish-release');
-  assert.equal(assetBuild.with.tag, '${{ github.ref_name }}');
+  assert.equal(assetBuild.with.tag, '${{ inputs.tag || github.ref_name }}');
   assert.deepEqual(packageDispatch.needs, [
     'publish-release',
     'build-release-assets',
   ]);
   assert.doesNotMatch(dispatchScript, /release-assets\.yml/u);
   assert.match(dispatchScript, /release-linux-packages\.yml/u);
+});
+
+test('release publishing admits only tag pushes and main-branch retries', () => {
+  const release = readWorkflow('release.yml');
+  const validation = release.jobs['validate-main-tag'];
+  const validationScript = validation.steps.find(
+    (step) => step.name === 'Ensure tag is on main'
+  ).run;
+
+  assert.match(validation.if, /github\.event_name != 'workflow_dispatch'/u);
+  assert.match(validation.if, /github\.ref == 'refs\/heads\/main'/u);
+  assert.match(validationScript, /\$GITHUB_EVENT_NAME" == 'push'/u);
+  assert.match(validationScript, /\$GITHUB_REF_TYPE" != 'tag'/u);
+  assert.match(validationScript, /git merge-base --is-ancestor/u);
 });
 
 test('release assets support trusted reuse and main-only manual dispatch', () => {


### PR DESCRIPTION
## Description

Fix the failing i18n and lint/test build checks in a separate PR.

The release workflow now limits manual retries to `main`, rejects non-tag push refs before privileged publishing, and keeps the reusable asset tag assertion aligned with the workflow input fallback. The Bookshelf installer test fixture is also formatted consistently with the repository.

**AI Disclosure:** This PR was written primarily by OpenAI Codex. Codex diagnosed the failures, implemented the changes, added the regression test and release-note fragment, and ran the verification listed below.

## How Has This Been Tested?

- `act pull_request -W .github/workflows/ci.yml -j i18n` — passed, including i18n extraction, 119 tooling tests, and both security boundary scans
- `act pull_request -W .github/workflows/ci.yml -j test` — passed lint, repository formatting, and the production client/server build in the pinned Alpine job container
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `node --test scripts/release-workflow.test.mjs scripts/release-notes.test.mjs` — 18 tests passed
- `pnpm release-notes:preview --base origin/main --head HEAD`

## Screenshots / Logs (if applicable)

Local GitHub Actions jobs completed with `Job succeeded` for both `i18n Check` and `Lint & Test Build`.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [ ] The fragment includes audience, area, action, and breaking-change status.
- [ ] I previewed the release text with `pnpm release-notes:preview`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
