### PR TITLE
fix(ci): publish real multi-arch amd64+arm64 images for :main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
+          - linux/arm64
     runs-on:
       [self-hosted, seerrng, linux-build, linux-amd64, linux-arm64-cross]
     steps:
@@ -236,6 +237,7 @@ jobs:
             BUILD_VERSION=${{ steps.channel.outputs.CHANNEL }}
             SOURCE_DATE_EPOCH=${{ steps.ts.outputs.TIMESTAMP }}
           cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false
 
   publish:
@@ -262,6 +264,11 @@ jobs:
       - name: Image channel
         id: channel
         run: echo "CHANNEL=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -346,12 +353,14 @@ jobs:
 
           build_args=(
             --file ./Dockerfile
-            --platform linux/amd64
+            --platform linux/amd64,linux/arm64
             --push
             --build-arg "COMMIT_TAG=${COMMIT_TAG}"
             --build-arg "BUILD_VERSION=${BUILD_VERSION}"
             --build-arg "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
             --cache-from type=gha,scope=linux/amd64
+            --cache-from type=gha,scope=linux/arm64
+            --cache-to type=gha,mode=max
             --provenance false
           )
 
@@ -395,6 +404,11 @@ jobs:
           persist-credentials: false
           clean: true
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: network=host
+
       - name: Log in to GitHub Container Registry on seerr.home
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -406,17 +420,29 @@ jobs:
         run: |
           set -euo pipefail
           image_name="ghcr.io/${GITHUB_REPOSITORY}"
-          docker pull "${image_name}:main"
-          mapfile -t digest_refs < <(
-            docker image inspect "${image_name}:main" \
-              --format '{{range .RepoDigests}}{{println .}}{{end}}' |
-              grep -E "^${image_name}@sha256:[0-9a-f]{64}$"
-          )
-          if (( ${#digest_refs[@]} != 1 )); then
-            echo 'Expected exactly one repository digest for the main image.' >&2
-            exit 1
-          fi
-          printf 'SEERRNG_IMAGE_REF=%s\n' "${digest_refs[0]}" >> "$GITHUB_ENV"
+          # ':main' now resolves to a multi-arch manifest list. Resolve its
+          # digest on the registry side with `imagetools inspect` (the same
+          # approach release.yml uses) rather than reading back
+          # `docker image inspect --format '{{.RepoDigests}}'`: once a tag
+          # points at an index, what that local field reports for a pulled
+          # image varies by Docker storage driver (classic image store vs.
+          # containerd image store) and is no longer reliably single-valued.
+          digest=""
+          for attempt in 1 2 3 4 5; do
+            echo "Resolving main image digest (attempt ${attempt}/5)"
+            if digest=$(docker buildx imagetools inspect "${image_name}:main" --format '{{json .Manifest.Digest}}' | tr -d '"') &&
+              [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo 'Unable to resolve the main image digest after 5 attempts.' >&2
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
+          image_ref="${image_name}@${digest}"
+          docker pull "$image_ref"
+          printf 'SEERRNG_IMAGE_REF=%s\n' "$image_ref" >> "$GITHUB_ENV"
 
       - name: Validate deployment inputs
         run: |

--- a/release-notes/fixed-main-image-arm64-build.md
+++ b/release-notes/fixed-main-image-arm64-build.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users, operators
+area: release-pipeline
+action: none
+breaking: false
+---
+The `:main` container image on GHCR is now published as a real multi-arch (amd64 + arm64) manifest, fixing "exec format error" crashes on arm64 hosts.


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

The `main`-branch CI pipeline in `.github/workflows/ci.yml` only ever produces
an `amd64` image, even though it's shaped like a multi-arch pipeline (job
names say "multi-arch", there's a QEMU step gated on `matrix.platform ==
'linux/arm64'`, and the sibling `preview.yml`/`release.yml` workflows already
build and push real `linux/amd64,linux/arm64` images). The result:
`ghcr.io/snapetech/seerrng:main` crashes with `exec format error` on arm64
hosts.

No tracked issue for this — found and root-caused directly while trying to
run `:main` on an arm64 host.

Root cause is one class of bug (platform info stops flowing through the
pipeline) showing up in five places in the `build`, `publish`, and
`deploy-main` jobs:

1. **`build` job matrix only listed `linux/amd64`.** The conditional
   `if: matrix.platform == 'linux/arm64'` QEMU step right below it only makes
   sense if `linux/arm64` was meant to be in the matrix — it never ran.
   → Added `linux/arm64` to `strategy.matrix.platform`.

2. **`build` job's "Warm cache" step had `cache-from` but no `cache-to`.**
   The whole point of that job (named "Build cache") is to populate the GHA
   layer cache per platform so the final push is fast; without `cache-to` it
   never wrote anything, for either platform. `preview.yml`'s identical step
   has both.
   → Added `cache-to: type=gha,mode=max,scope=${{ matrix.platform }}`.

3. **`publish` job hardcoded `--platform linux/amd64`** in the "Build & Push
   (multi-arch, single tag)" step. Even with #1 fixed, this alone would still
   force a single-arch push.
   → Changed to `--platform linux/amd64,linux/arm64`. `docker buildx build
   --push` with a comma-separated platform list builds and pushes both
   platforms as one manifest list in a single invocation — this is exactly
   the pattern `release.yml`'s publish step already uses, so there's no
   separate `imagetools create` merge step to add here; the combined build
   *is* the merge.

4. **`publish` job had no "Set up QEMU" step at all.** The `build` job gets
   arm64 emulation from its conditional step; `publish` does the real
   build+push and needs it too, unconditionally (it always builds both
   platforms in one call, since it isn't matrixed).
   → Added an unconditional `docker/setup-qemu-action` step, same pinned
   version already used in `build`.

5. **`publish` job's `--cache-from` was hardcoded to `scope=linux/amd64`
   only,** so the arm64 leg of the build would never hit a warm cache.
   → Added a second `--cache-from type=gha,scope=linux/arm64` and a
   `--cache-to type=gha,mode=max`, matching `release.yml`'s publish step
   exactly.

6. **`deploy-main` job's digest check assumed exactly one `RepoDigest`.** It
   ran `docker image inspect ghcr.io/.../seerrng:main --format
   '{{.RepoDigests}}'` and hard-failed unless that returned exactly one
   entry. That's a reasonable check for a single-arch tag, but once `:main`
   resolves to a multi-arch manifest list, what a *locally pulled* image's
   `RepoDigests` reports differs across Docker storage drivers (classic image
   store vs. containerd image store), so the `!= 1` guard is no longer a
   reliable single-valued check.
   → Replaced it with `docker buildx imagetools inspect
   ghcr.io/.../seerrng:main --format '{{json .Manifest.Digest}}'` (queries
   the registry directly, independent of local storage driver — the exact
   pattern `release.yml`'s own "Resolve manifest digest" step already uses),
   then pull by that resolved digest. Also added the "Set up Docker Buildx"
   step this job was missing (needed for `imagetools inspect` to be
   available).

**Verified, not changed:** the `Dockerfile` itself needs no edits. Its pinned
base image
(`public.ecr.aws/docker/library/node:22.22.2-alpine3.23@sha256:8ea23...`) is
already a multi-arch manifest list that includes `linux/arm64/v8`
(`docker buildx imagetools inspect` confirms this), and `preview.yml`/
`release.yml` already build `linux/arm64` successfully from this same
Dockerfile — so the bug was fully contained to `ci.yml`.

**Flagging, not changing:** `ci.yml`'s `build`/`publish` jobs run on a single
shared self-hosted runner pool labeled with both `linux-amd64` and
`linux-arm64-cross`, using an explicit `docker/setup-qemu-action` step for
the arm64 leg. `preview.yml`/`release.yml` instead select a runner
specifically labeled `linux-arm64-cross` per matrix entry and *never* call
`setup-qemu-action`, which implies arm64 emulation may already be registered
at the host/infra level for those runners. I kept `ci.yml`'s existing,
self-sufficient approach (explicit QEMU setup) rather than assume the same
infra guarantee holds for this runner pool — happy to switch to the other
pattern if a maintainer confirms it applies here too, but didn't want to
guess at infra I can't see.

## How Has This Been Tested?

This is a workflow-only change (no application code touched), and the fixed
jobs only run on `push` to `main` against this repo's own self-hosted
runners, so I could not trigger a real end-to-end run of `build`/`publish`/
`deploy-main` from a fork PR. What I did verify:

- `python3 -c "import yaml; yaml.safe_load(...)"` — the edited `ci.yml`
  parses as valid YAML.
- Walked the parsed job/step structure to confirm the matrix, conditionals,
  and every `--platform`/`--cache-from`/`--cache-to` string agree with each
  other post-fix (no leftover single-arch string anywhere in the file).
- `docker buildx imagetools inspect` against the Dockerfile's pinned base
  image digest, confirming it's a manifest list containing `linux/arm64/v8`.
- Diffed the fixed `build`/`publish`/cache logic line-by-line against the
  already-working, already-multi-arch `preview.yml` and `release.yml`
  workflows in this same repo, which build/push this same Dockerfile for
  `linux/amd64,linux/arm64` today — the fix makes `ci.yml` structurally
  match them rather than introducing a new, unproven pattern.

I was not able to run `pnpm build`/tests locally in the environment I used
for this (no Node toolchain available there), but this PR doesn't touch any
application code, package files, or anything else those checks cover — only
`.github/workflows/ci.yml` and one new `release-notes/` fragment. The repo's
own `i18n`/`test`/`unit-test` CI jobs run against this PR via the
`pull_request` trigger regardless. I'd still ask a maintainer to watch the
first real `main` run of `build`/`publish`/`deploy-main` after merge, since
that's the one thing I structurally couldn't rehearse here.

## Screenshots / Logs (if applicable)

N/A — CI/workflow change, no UI surface.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [ ] The fragment includes audience, area, action, and breaking-change status. (It does — see `release-notes/fixed-main-image-arm64-build.md`; leaving this box unchecked because the PR-template checker only allows one checked box in this section.)
- [ ] I previewed the release text with `pnpm release-notes:preview`. (Could not run `pnpm` in the environment used for this change; manually checked the fragment against `release-notes/README.md`'s schema and an existing fragment for format.)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly. (N/A — no user-facing docs describe per-arch CI behavior.)
- [ ] All new and existing tests passed. (Not run locally; no application code changed. Relying on this PR's own CI for lint/build/unit tests, and asking a maintainer to watch the first real `main`-branch multi-arch run post-merge, per the testing note above.)
- [ ] Successful build `pnpm build` (Not run locally — no Node toolchain in the environment used for this change; this PR does not touch any code `pnpm build` covers.)
- [ ] Translation keys `pnpm i18n:extract` (N/A — no UI strings changed.)
- [ ] Database migration (if required) (N/A.)

---

**AI Disclosure:** This PR was written primarily by Claude Code. I gave it
two confirmed leads (the missing `linux/arm64` matrix entry, and the
hardcoded `--platform linux/amd64` in the publish step) and asked it to trace
the same bug class through the rest of `ci.yml` and the release/tag path,
fix everything it found, and flag anything ambiguous instead of guessing.
It found and fixed the additional cache-scoping and missing-QEMU issues in
the `publish` job and the digest-assumption issue in `deploy-main` described
above on its own, cross-checking each fix against the already-correct
multi-arch logic already present in `preview.yml`/`release.yml`, and flagged
the QEMU-vs-runner-label discrepancy between `ci.yml` and its sibling
workflows rather than silently changing it.
