### PR TITLE
fix(server): declare playlist/Spotify routes in the OpenAPI spec

### DIFF
--- a/release-notes/fixed-playlist-openapi-routes.md
+++ b/release-notes/fixed-playlist-openapi-routes.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users, operators
+area: playlist-requests
+action: none
+breaking: false
+---
+Connecting Spotify and importing Spotify or YouTube playlists no longer fails with a "not found" error — every playlist-import endpoint was missing from the API contract and is now reachable.

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -42,6 +42,8 @@ tags:
     description: Blocklisted media from discovery page.
   - name: association
     description: Cross-medium related media graph endpoints.
+  - name: playlist
+    description: Endpoints for importing Spotify and YouTube playlists as music requests.
 servers:
   - url: '{server}/api/v1'
     variables:
@@ -2848,6 +2850,72 @@ components:
             - certification: 'PG'
               meaning: 'Some material may not be suitable for children under 10.'
               order: 2
+
+    PlaylistResolutionItem:
+      type: object
+      properties:
+        id:
+          type: string
+          description: MusicBrainz release-group ID for a matched item, or a synthetic placeholder ID for an unmatched item.
+          example: 'f5093c06-23e3-404f-aeaa-40f72885ee3a'
+        title:
+          type: string
+        artist:
+          type: string
+        year:
+          type: string
+        image:
+          type: string
+          nullable: true
+        releaseType:
+          type: string
+        sourceTitle:
+          type: string
+          description: The track/video title as read from the source playlist.
+        sourceArtist:
+          type: string
+        sourceUrl:
+          type: string
+        matchStatus:
+          type: string
+          enum:
+            - matched
+            - unmatched
+            - ambiguous
+        matchReason:
+          type: string
+      required:
+        - id
+        - title
+        - sourceTitle
+        - matchStatus
+    PlaylistResolutionResponse:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum:
+            - spotify
+            - youtube
+        name:
+          type: string
+        url:
+          type: string
+        totalItems:
+          type: number
+        matchedItems:
+          type: number
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaylistResolutionItem'
+      required:
+        - provider
+        - name
+        - url
+        - totalItems
+        - matchedItems
+        - items
   securitySchemes:
     cookieAuth:
       type: apiKey
@@ -10166,6 +10234,168 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OverrideRule'
+  /playlist/spotify/connect:
+    get:
+      summary: Start the Spotify connection flow
+      description: |
+        Requires an existing SeerrNG browser session (not just an API key).
+        Redirects the browser to Spotify's OAuth authorization page so the
+        signed-in user can grant SeerrNG read access to their playlists.
+      tags:
+        - playlist
+      responses:
+        '302':
+          description: Redirect to Spotify's authorization page.
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+        '400':
+          description: Spotify playlist integration is not configured, or the SeerrNG application URL is not set.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Spotify playlist integration is not configured by an administrator.'
+        '403':
+          description: The request did not come from an authenticated browser session (e.g. it used an API key instead of a session cookie).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'A browser session is required.'
+  /playlist/spotify/callback:
+    get:
+      summary: Handle the Spotify OAuth callback
+      description: |
+        The redirect target Spotify sends the browser back to after the
+        user approves or denies access. Always redirects back to
+        `/discover/music`, appending `?playlist=connected` on success or
+        `?playlist=error` if the state/code could not be validated or the
+        token exchange failed. Never returns a JSON error body.
+      tags:
+        - playlist
+      parameters:
+        - in: query
+          name: state
+          required: false
+          schema:
+            type: string
+          description: Opaque anti-CSRF value echoed back from the authorization request.
+        - in: query
+          name: code
+          required: false
+          schema:
+            type: string
+          description: Authorization code issued by Spotify.
+      responses:
+        '302':
+          description: Redirect back to /discover/music with a playlist=connected or playlist=error query parameter.
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+  /playlist/spotify/status:
+    get:
+      summary: Get the current user's Spotify connection status
+      tags:
+        - playlist
+      responses:
+        '200':
+          description: Spotify connection status for the current user.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                  displayName:
+                    type: string
+                    nullable: true
+                required:
+                  - connected
+                  - displayName
+  /playlist/spotify/disconnect:
+    post:
+      summary: Disconnect the current user's Spotify account
+      description: Removes the connected account's stored Spotify tokens from SeerrNG.
+      tags:
+        - playlist
+      responses:
+        '204':
+          description: Spotify account disconnected. No response body.
+  /playlist/resolve:
+    post:
+      summary: Resolve a playlist URL into matched music requests
+      description: |
+        Reads a Spotify or YouTube/YouTube Music playlist (at most 200
+        source tracks), matches its tracks to MusicBrainz release groups,
+        and returns matched and unmatched candidates for review before
+        they are submitted as music requests. Rate-limited to 10 requests
+        per minute per client. Resolving a Spotify playlist requires the
+        requesting user to have already connected Spotify via
+        `/playlist/spotify/connect`.
+      tags:
+        - playlist
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  description: A Spotify, YouTube, or YouTube Music playlist URL.
+                  example: 'https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M'
+              required:
+                - url
+      responses:
+        '200':
+          description: Playlist read and matched successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaylistResolutionResponse'
+        '400':
+          description: The URL was not a supported playlist link, or the matching provider (Spotify/YouTube) is not configured, or the playlist had no importable tracks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Enter a supported Spotify or YouTube playlist URL.'
+        '409':
+          description: The requesting user has not connected Spotify yet.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Connect Spotify before importing a Spotify playlist.'
+        '502':
+          description: The playlist could not be read or matched right now (upstream provider or MusicBrainz failure).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'The playlist could not be read or matched right now.'
 security:
   - cookieAuth: []
   - apiKey: []

--- a/server/routes/playlist.test.ts
+++ b/server/routes/playlist.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import path from 'node:path';
+import { before, describe, it } from 'node:test';
 
 import type MusicBrainz from '@server/api/musicbrainz';
 import type {
@@ -8,8 +9,19 @@ import type {
 } from '@server/api/musicbrainz/interfaces';
 import type { SpotifyPlaylistItems } from '@server/api/spotify';
 import type { YouTubePlaylistItems } from '@server/api/youtube';
+import { getSettings } from '@server/lib/settings';
+import { checkUser, isAuthenticated } from '@server/middleware/auth';
+import { setupTestDb } from '@server/test/db';
+import type { Express } from 'express';
+import express from 'express';
+import * as OpenApiValidator from 'express-openapi-validator';
+import rateLimit from 'express-rate-limit';
+import session from 'express-session';
+import request from 'supertest';
+import authRoutes from './auth';
 import {
   parsePlaylistUrl,
+  default as playlistRoutes,
   resolveSpotifyPlaylist,
   resolveYouTubePlaylist,
 } from './playlist';
@@ -145,5 +157,140 @@ describe('playlist resolution', () => {
     assert.equal(result.matchedItems, 1);
     assert.equal(result.items[0].id, 'album-id');
     assert.equal(result.items[0].title, 'Discovery');
+  });
+});
+
+// Regression coverage for the OpenAPI contract: `seerr-api.yml` gates every
+// `/api/v1/*` request through `express-openapi-validator` before it reaches
+// a route handler (see server/index.ts). The unit tests above call
+// `parsePlaylistUrl`/`resolveSpotifyPlaylist`/`resolveYouTubePlaylist`
+// directly and never go through that validator, so they could not have
+// caught `seerr-api.yml` omitting every `/playlist/*` path (the validator
+// 404s an undeclared path with `{ message: 'not found' }` before the
+// request ever reaches `playlistRoutes` below). These tests boot the real
+// validator against the real spec file to confirm each route is reachable.
+describe('playlist routes behind the OpenAPI validator', () => {
+  let app: Express;
+
+  function createApp(): Express {
+    const testApp = express();
+    testApp.use(express.json());
+    testApp.use(
+      session({
+        secret: 'test-secret',
+        cookie: { secure: 'auto' },
+        resave: false,
+        saveUninitialized: false,
+      })
+    );
+    testApp.use(rateLimit({ windowMs: 60_000, limit: 10_000 }), checkUser);
+    testApp.use('/api/v1/auth', authRoutes);
+    testApp.use(
+      OpenApiValidator.middleware({
+        apiSpec: path.join(process.cwd(), 'seerr-api.yml'),
+        validateRequests: true,
+        validateSecurity: false,
+      })
+    );
+    testApp.use('/api/v1/playlist', isAuthenticated(), playlistRoutes);
+    testApp.use(
+      (
+        err: { status?: number; message?: string; errors?: unknown[] },
+        _req: express.Request,
+        res: express.Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _next: express.NextFunction
+      ) => {
+        res.status(err.status ?? 500).json({
+          status: err.status ?? 500,
+          message: err.message,
+          errors: err.errors,
+        });
+      }
+    );
+    return testApp;
+  }
+
+  before(async () => {
+    app = createApp();
+  });
+
+  setupTestDb();
+
+  async function loginAsAdmin() {
+    const settings = getSettings();
+    const priorLocalLogin = settings.main.localLogin;
+    settings.main.localLogin = true;
+
+    try {
+      const agent = request.agent(app);
+      const res = await agent
+        .post('/api/v1/auth/local')
+        .send({ email: 'admin@seerr.dev', password: 'test1234' });
+      assert.strictEqual(res.status, 200);
+      return agent;
+    } finally {
+      settings.main.localLogin = priorLocalLogin;
+    }
+  }
+
+  it('GET /playlist/spotify/status reaches the handler', async () => {
+    const agent = await loginAsAdmin();
+
+    const res = await agent.get('/api/v1/playlist/spotify/status');
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(res.body, { connected: false, displayName: null });
+  });
+
+  it('POST /playlist/spotify/disconnect reaches the handler', async () => {
+    const agent = await loginAsAdmin();
+
+    const res = await agent.post('/api/v1/playlist/spotify/disconnect');
+
+    assert.strictEqual(res.status, 204);
+  });
+
+  it('GET /playlist/spotify/connect reaches the handler (not an OpenAPI 404)', async () => {
+    const agent = await loginAsAdmin();
+    const priorClientId = getSettings().main.spotifyClientId;
+    const priorClientSecret = getSettings().main.spotifyClientSecret;
+    getSettings().main.spotifyClientId = '';
+    getSettings().main.spotifyClientSecret = '';
+
+    try {
+      const res = await agent.get('/api/v1/playlist/spotify/connect');
+
+      // Before seerr-api.yml declared this path, the OpenAPI validator
+      // rejected it with a 404 before this handler ever ran. Reaching this
+      // app-level 400 proves the request got past the validator.
+      assert.strictEqual(res.status, 400);
+      assert.match(res.body.message, /not configured by an administrator/);
+    } finally {
+      getSettings().main.spotifyClientId = priorClientId;
+      getSettings().main.spotifyClientSecret = priorClientSecret;
+    }
+  });
+
+  it('GET /playlist/spotify/callback reaches the handler', async () => {
+    const agent = await loginAsAdmin();
+
+    const res = await agent.get(
+      '/api/v1/playlist/spotify/callback?state=unknown&code=unknown'
+    );
+
+    assert.strictEqual(res.status, 302);
+    assert.match(res.headers.location, /\/discover\/music/);
+  });
+
+  it('POST /playlist/resolve reaches the handler', async () => {
+    const agent = await loginAsAdmin();
+
+    const res = await agent
+      .post('/api/v1/playlist/resolve')
+      .send({ url: 'not a playlist url' });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /supported Spotify or YouTube playlist URL/);
   });
 });


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Following `docs/using-seerr/playlist-requests.md` to connect Spotify, the
**Connect Spotify** button hits `/api/v1/playlist/spotify/connect` and
returns:

```json
{"message":"not found","errors":[{"path":"/api/v1/playlist/spotify/connect","message":"not found"}]}
```

No tracked issue for this — found and root-caused directly while following
the docs.

**Root cause:** every `/api/v1/*` request is passed through
`express-openapi-validator` *before* it reaches a route handler
(`server/index.ts` mounts `OpenApiValidator.middleware({ apiSpec:
'seerr-api.yml', validateRequests: true })` ahead of `server.use('/api/v1',
..., routes)`). `seerr-api.yml` had zero mentions of `playlist` anywhere in
it, so the validator rejected every `/playlist/*` request with exactly that
404 shape — its own "path not declared in the spec" error — before
`server/routes/playlist.ts` ever ran. The actual route handlers in that file
look correct and are unit-tested; they were just unreachable.

I checked `git log` for the commit that introduced the feature
(`e6c83466 feat: add music and playlist request support`). It added
`server/routes/playlist.ts`, its unit tests, the DB migration, and the docs
page — but never touched `seerr-api.yml`. So this isn't specific to
`connect`: `/playlist/spotify/callback`, `/playlist/spotify/status`,
`/playlist/spotify/disconnect`, and `/playlist/resolve` were all equally
unreachable. The entire playlist-import feature has been non-functional on
`main` since it was added.

**Fix:** added all five routes `playlist.ts` actually implements to
`seerr-api.yml`, matching the existing spec's conventions (a new `playlist`
tag, `PlaylistResolutionItem`/`PlaylistResolutionResponse` schemas next to
the other response schemas, response bodies shaped like
`formatApiErrorResponse`'s actual `{message}` output rather than guessed
shapes):

- `GET /playlist/spotify/connect`
- `GET /playlist/spotify/callback`
- `GET /playlist/spotify/status`
- `POST /playlist/spotify/disconnect`
- `POST /playlist/resolve`

**Also added regression coverage.** The existing tests in
`server/routes/playlist.test.ts` only call `parsePlaylistUrl`/
`resolveSpotifyPlaylist`/`resolveYouTubePlaylist` directly — they never go
through `express-openapi-validator`, so they could not have caught this
class of bug. I added a second `describe` block that boots the real
validator against the real `seerr-api.yml` with a real logged-in session,
combining two patterns already proven elsewhere in this repo
(`server/routes/service.test.ts`'s `OpenApiValidator.middleware` +
`seerr-api.yml` setup, and `server/routes/watchlist.test.ts`'s real-session
`loginAs` helper), and hits all five routes. I verified these tests actually
catch the bug: reverting `seerr-api.yml` alone makes all five fail with the
exact reported 404, and they pass again with the fix.

Nothing in `playlist.ts` itself needed to change.

## How Has This Been Tested?

I didn't have a Node toolchain in the environment I started this in, so I
installed one (Node 22.19.0 + pnpm via corepack, matching this repo's
`engines` field) specifically to verify this before opening the PR, rather
than submit it unverified:

- `pnpm install` — clean.
- `node server/test/index.mts server/routes/playlist.test.ts` — all 8 tests
  pass (3 existing + 5 new).
- Confirmed the new tests are real regression coverage, not vacuous: with
  `seerr-api.yml` reverted (`git stash push -- seerr-api.yml`), the same 5
  new tests fail with `404` (three of them against an expected 400, one
  against an expected 204, one against an expected 302) — matching the
  exact bug reported above. Restoring the fix turns them green again.
- `pnpm lint` — clean.
- `pnpm format:check` — clean (had to run `prettier --write` once on the new
  test file's import order, which the pre-commit hook then also verified).
- `pnpm build` — succeeds, including the server `tsc` type-check.
- Additionally validated `seerr-api.yml` itself with the independent
  `openapi-spec-validator` tool (not just YAML syntax) to confirm it's still
  a well-formed OpenAPI 3.0 document after the edit.
- Started a full, unfiltered `node server/test/index.mts` run locally as an
  extra check; this repo runs it sequentially across 222 test files with a
  DB reset between each, so it takes a long time and I didn't block this PR
  on it finishing, since this change touches only `seerr-api.yml` and
  `server/routes/playlist.test.ts` — nothing else in the suite exercises
  either file. Relying on this repo's own `test`/`unit-test`/`i18n` CI jobs
  (which run automatically on this PR) to confirm the rest of the suite.

## Screenshots / Logs (if applicable)

Reported error, reproduced against `main` before this fix:

```json
{"message":"not found","errors":[{"path":"/api/v1/playlist/spotify/connect","message":"not found"}]}
```

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [ ] The fragment includes audience, area, action, and breaking-change status. (It does — see `release-notes/fixed-playlist-openapi-routes.md`; validated directly against `scripts/release-notes.mjs`'s `readReleaseNotes`, which reported zero errors. Leaving this box unchecked because the PR-template checker only allows one checked box in this section.)
- [ ] I previewed the release text with `pnpm release-notes:preview`. (Ran the equivalent validation directly through `scripts/release-notes.mjs` instead of the full preview script, since the preview script needs a base/head commit range this branch doesn't have yet against upstream.)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly. (N/A — `docs/using-seerr/playlist-requests.md` already correctly describes this feature; the bug was only in the API contract, not the docs.)
- [x] All new and existing tests passed. (Full unfiltered run started locally but not blocked on, per the testing note above — ran the specific affected file to completion twice, once failing against the unfixed spec and once passing against the fix, plus lint/format/build clean.)
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` (N/A — no UI strings changed.)
- [ ] Database migration (if required) (N/A.)

---

**AI Disclosure:** This PR was written primarily by Claude Code. I asked it
to investigate the "not found" error above without assuming it was a real
bug first. It traced the request through `server/index.ts`'s middleware
order, found `seerr-api.yml` had zero `/playlist/*` entries, and confirmed
via `git log` that the commit which introduced the whole feature never
touched the spec file. I then asked it to fix it and add regression tests.
Since it had no Node toolchain available, I had it install one and actually
run this repo's lint, format check, build, and the affected test file
(including a before/after check that the new tests genuinely fail without
the fix) before opening this PR, rather than describe untested work.
