### PR TITLE
fix(discover): preserve list order and scroll when returning from details

### DIFF
--- a/cypress/e2e/library-discover-parity.cy.ts
+++ b/cypress/e2e/library-discover-parity.cy.ts
@@ -99,10 +99,10 @@ describe('Books and Music discover parity', () => {
       results: [],
     });
 
-    cy.wrap(themePalettes).each((palette) => {
+    themePalettes.forEach((palette) => {
       cy.visit('/discover/movies', {
         onBeforeLoad(win) {
-          win.localStorage.setItem('seerr-theme-palette', palette as string);
+          win.localStorage.setItem('seerr-theme-palette', palette);
           win.localStorage.setItem('seerr-theme-mode', 'dark');
         },
       });
@@ -128,7 +128,7 @@ describe('Books and Music discover parity', () => {
 
         cy.visit('/discover/movies', {
           onBeforeLoad(win) {
-            win.localStorage.setItem('seerr-theme-palette', palette as string);
+            win.localStorage.setItem('seerr-theme-palette', palette);
             win.localStorage.setItem('seerr-theme-mode', 'light');
           },
         });
@@ -413,8 +413,25 @@ describe('Books and Music discover parity', () => {
     cy.contains('[data-testid=modal-title]', 'Requestable Book').should(
       'be.visible'
     );
-    cy.contains('label', 'Format').should('be.visible');
-    cy.get('select[name=bookFormat]').should('be.visible');
+    cy.contains('legend', 'Format').should('be.visible');
+    cy.get('[role=radiogroup][aria-label=Format]').within(() => {
+      cy.get('[title=Ebook]')
+        .closest('[role=radio]')
+        .should('have.attr', 'aria-checked', 'true');
+      cy.get('[title=Audiobook]')
+        .closest('[role=radio]')
+        .click()
+        .should('have.attr', 'aria-checked', 'true');
+    });
+    cy.contains('[data-testid=modal-title]', 'Request Audiobook')
+      .scrollIntoView()
+      .should('be.visible');
+    cy.contains('[role=radio]', 'Ebook + Audiobook')
+      .click()
+      .should('have.attr', 'aria-checked', 'true');
+    cy.contains('[data-testid=modal-title]', 'Request Ebook + Audiobook')
+      .scrollIntoView()
+      .should('be.visible');
     cy.contains('label', 'Edition / ISBN').should('be.visible');
     cy.get('select[name=isbn]').should('be.visible');
     cy.contains('Automatic best match').should('be.visible');

--- a/release-notes/fix-discover-back-scroll.md
+++ b/release-notes/fix-discover-back-scroll.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users
+area: discover
+action: none
+breaking: false
+---
+Returning from movie, series, or book details now preserves the discovery list order and restores your previous scroll position after the results have loaded.

--- a/release-notes/media-type-badges.md
+++ b/release-notes/media-type-badges.md
@@ -1,0 +1,8 @@
+---
+category: changed
+audience: users
+area: media-ui
+action: none
+breaking: false
+---
+Media cards and request lists now show consistent badges for movies, series, albums, artists, collections, and books so each title’s media type is clear at a glance.

--- a/src/components/ArtistCard/index.tsx
+++ b/src/components/ArtistCard/index.tsx
@@ -1,4 +1,5 @@
 import CachedImage from '@app/components/Common/CachedImage';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import { encodeApiPathSegment } from '@app/utils/apiPath';
 import { UserCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
@@ -47,6 +48,9 @@ const ArtistCard = ({
       >
         <div style={{ paddingBottom: '150%' }}>
           <div className="absolute inset-0 flex h-full w-full flex-col items-center p-2">
+            <div className="absolute left-2 top-2 z-10">
+              <MediaTypeBadge mediaType="artist" variant="card" />
+            </div>
             <div className="relative mb-4 mt-2 flex h-1/2 w-full justify-center">
               {artistThumb ? (
                 <div className="relative h-full w-3/4 overflow-hidden rounded-full ring-1 ring-gray-700">

--- a/src/components/ArtistDetails/index.tsx
+++ b/src/components/ArtistDetails/index.tsx
@@ -2,6 +2,7 @@ import AssociationBadge from '@app/components/Association/AssociationBadge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import MediaSlider from '@app/components/MediaSlider';
 import BulkRequestModal from '@app/components/RequestModal/BulkRequestModal';
@@ -236,6 +237,7 @@ const ArtistDetails = () => {
         )}
         <div className="min-w-0 text-center lg:text-left">
           <div className="flex min-w-0 flex-wrap items-center justify-center gap-3 lg:justify-start">
+            <MediaTypeBadge mediaType="artist" variant="inline" />
             <h1 className="min-w-0 break-words text-3xl font-bold text-white lg:text-5xl">
               {artistName}
             </h1>

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import ButtonWithDropdown from '@app/components/Common/ButtonWithDropdown';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import Tooltip from '@app/components/Common/Tooltip';
 import Slider from '@app/components/Slider';
@@ -367,6 +368,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
         </div>
         <div className="media-title">
           <div className="media-status">
+            <MediaTypeBadge mediaType="collection" variant="inline" />
             <StatusBadge
               status={collectionStatus}
               downloadItem={downloadStatus}

--- a/src/components/Common/MediaTypeBadge/index.tsx
+++ b/src/components/Common/MediaTypeBadge/index.tsx
@@ -1,0 +1,122 @@
+import globalMessages from '@app/i18n/globalMessages';
+import {
+  BookOpenIcon,
+  FilmIcon,
+  MusicalNoteIcon,
+  RectangleStackIcon,
+  TvIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/outline';
+import { useIntl } from 'react-intl';
+import { twMerge } from 'tailwind-merge';
+
+export type MediaTypeBadgeType =
+  | 'movie'
+  | 'tv'
+  | 'collection'
+  | 'album'
+  | 'artist'
+  | 'book';
+
+export const getMediaTypeBadgeType = (
+  mediaType: string
+): MediaTypeBadgeType | undefined => {
+  if (mediaType === 'music') {
+    return 'album';
+  }
+
+  if (
+    mediaType === 'movie' ||
+    mediaType === 'tv' ||
+    mediaType === 'collection' ||
+    mediaType === 'album' ||
+    mediaType === 'artist' ||
+    mediaType === 'book'
+  ) {
+    return mediaType;
+  }
+
+  return undefined;
+};
+
+interface MediaTypeBadgeProps {
+  mediaType: MediaTypeBadgeType;
+  variant?: 'card' | 'compact' | 'inline';
+  className?: string;
+  showIcon?: boolean;
+}
+
+const badgeConfig = {
+  movie: {
+    message: globalMessages.movie,
+    icon: FilmIcon,
+    tone: 'border-blue-500 bg-blue-600/85 text-white',
+  },
+  tv: {
+    message: globalMessages.tvshow,
+    icon: TvIcon,
+    tone: 'border-purple-600 bg-purple-600/85 text-white',
+  },
+  collection: {
+    message: globalMessages.collection,
+    icon: RectangleStackIcon,
+    tone: 'border-blue-500 bg-blue-600/85 text-white',
+  },
+  album: {
+    message: globalMessages.album,
+    icon: MusicalNoteIcon,
+    tone: 'border-emerald-500 bg-emerald-600/85 text-white',
+  },
+  artist: {
+    message: globalMessages.artist,
+    icon: UserCircleIcon,
+    tone: 'border-fuchsia-500 bg-fuchsia-600/85 text-white',
+  },
+  book: {
+    message: globalMessages.book,
+    icon: BookOpenIcon,
+    tone: 'border-amber-500 bg-amber-600/85 text-white',
+  },
+} as const satisfies Record<
+  MediaTypeBadgeType,
+  {
+    message: (typeof globalMessages)[keyof typeof globalMessages];
+    icon: typeof FilmIcon;
+    tone: string;
+  }
+>;
+
+const variantClasses = {
+  card: 'px-2 py-1 text-[11px] shadow-md',
+  compact: 'px-2 py-1 text-[11px]',
+  inline: 'px-2 py-1 text-xs',
+} as const;
+
+const MediaTypeBadge = ({
+  mediaType,
+  variant = 'compact',
+  className,
+  showIcon = true,
+}: MediaTypeBadgeProps) => {
+  const intl = useIntl();
+  const config = badgeConfig[mediaType];
+  const label = intl.formatMessage(config.message);
+  const Icon = config.icon;
+
+  return (
+    <span
+      className={twMerge(
+        'inline-flex max-w-full items-center gap-1 rounded-full border font-semibold leading-none',
+        variantClasses[variant],
+        config.tone,
+        className
+      )}
+      title={label}
+    >
+      {showIcon && <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
+      <span className="truncate">{label}</span>
+    </span>
+  );
+};
+
+export default MediaTypeBadge;

--- a/src/components/Discover/DiscoverBooks/index.tsx
+++ b/src/components/Discover/DiscoverBooks/index.tsx
@@ -63,6 +63,7 @@ const DiscoverBooks = () => {
     isLoadingMore,
     isReachingEnd,
     titles,
+    shuffleSeed,
     fetchMore,
   } = useDiscover<BookResult>(
     '/api/v1/discover/books',
@@ -72,6 +73,7 @@ const DiscoverBooks = () => {
   useDiscoverScrollRestoration({
     mediaType: 'book',
     itemCount: titles.length,
+    shuffleSeed,
     isLoading: isLoadingInitialData || isLoadingMore,
     isReachingEnd,
     fetchMore,

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -64,6 +64,7 @@ const DiscoverMovies = () => {
     isLoadingMore,
     isReachingEnd,
     titles,
+    shuffleSeed,
     fetchMore,
     error,
   } = useDiscover<MovieResult, unknown, FilterOptions>(
@@ -74,6 +75,7 @@ const DiscoverMovies = () => {
   useDiscoverScrollRestoration({
     mediaType: 'movie',
     itemCount: titles.length,
+    shuffleSeed,
     isLoading: isLoadingInitialData || isLoadingMore,
     isReachingEnd,
     fetchMore,

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -64,6 +64,7 @@ const DiscoverTv = () => {
     isLoadingMore,
     isReachingEnd,
     titles,
+    shuffleSeed,
     fetchMore,
     error,
   } = useDiscover<TvResult, never, FilterOptions>(
@@ -76,6 +77,7 @@ const DiscoverTv = () => {
   useDiscoverScrollRestoration({
     mediaType: 'tv',
     itemCount: titles.length,
+    shuffleSeed,
     isLoading: isLoadingInitialData || isLoadingMore,
     isReachingEnd,
     fetchMore,

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -9,6 +9,7 @@ import AssociationBadge from '@app/components/Association/AssociationBadge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import type { PlayButtonLink } from '@app/components/Common/PlayButton';
 import PlayButton from '@app/components/Common/PlayButton';
@@ -534,6 +535,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
         </div>
         <div className="media-title">
           <div className="media-status">
+            <MediaTypeBadge mediaType="movie" variant="inline" />
             <StatusBadge
               status={data.mediaInfo?.status}
               downloadItem={data.mediaInfo?.downloadStatus}

--- a/src/components/MusicDetails/index.tsx
+++ b/src/components/MusicDetails/index.tsx
@@ -3,6 +3,7 @@ import AssociationBadge from '@app/components/Association/AssociationBadge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import Tooltip from '@app/components/Common/Tooltip';
 import IssueBlock from '@app/components/IssueBlock';
@@ -366,9 +367,11 @@ const MusicDetails = () => {
         </div>
         <div className="min-w-0 flex-1 text-gray-300">
           <div className="mb-3 flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-emerald-500 bg-emerald-600/80 px-3 py-1 text-xs font-medium uppercase tracking-wider text-white">
-              {intl.formatMessage(messages.album)}
-            </span>
+            <MediaTypeBadge
+              mediaType="album"
+              variant="inline"
+              className="px-3 py-1 text-xs uppercase tracking-wider"
+            />
             {data.mediaInfo?.status &&
               data.mediaInfo.status !== MediaStatus.UNKNOWN && (
                 <StatusBadge

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -5,6 +5,9 @@ import BookFormatBadge, {
 } from '@app/components/Common/BookFormatBadge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
+import MediaTypeBadge, {
+  getMediaTypeBadgeType,
+} from '@app/components/Common/MediaTypeBadge';
 import Tooltip from '@app/components/Common/Tooltip';
 import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
@@ -566,15 +569,26 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
           className="relative z-10 flex min-w-0 flex-1 flex-col pr-4"
           data-testid="request-card-title"
         >
-          <div className="hidden text-xs font-medium text-white sm:flex">
-            {(isMovie(title)
-              ? title.releaseDate
-              : isMusic(title)
+          <div className="hidden flex-wrap items-center gap-1 text-xs font-medium text-white sm:flex">
+            {requestData.type !== 'book' && (
+              <MediaTypeBadge
+                mediaType={getMediaTypeBadgeType(requestData.type) ?? 'movie'}
+                variant="compact"
+              />
+            )}
+            {requestData.type !== 'book' && requestData.is4k && (
+              <Badge badgeType="warning">4K</Badge>
+            )}
+            <span>
+              {(isMovie(title)
                 ? title.releaseDate
-                : isBook(title)
-                  ? title.firstPublishYear?.toString()
-                  : title.firstAirDate
-            )?.slice(0, 4)}
+                : isMusic(title)
+                  ? title.releaseDate
+                  : isBook(title)
+                    ? title.firstPublishYear?.toString()
+                    : title.firstAirDate
+              )?.slice(0, 4)}
+            </span>
             {isMusic(title) && (
               <>
                 <span className="mx-2">-</span>

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -6,6 +6,9 @@ import BookFormatBadge, {
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
+import MediaTypeBadge, {
+  getMediaTypeBadgeType,
+} from '@app/components/Common/MediaTypeBadge';
 import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import useToasts from '@app/hooks/useToasts';
@@ -713,15 +716,28 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
               />
             </Link>
             <div className="flex flex-col justify-center overflow-hidden pl-2 xl:pl-4">
-              <div className="pt-0.5 text-xs font-medium text-white sm:pt-1">
-                {(isMovie(title)
-                  ? title.releaseDate
-                  : isMusic(title)
+              <div className="flex flex-wrap items-center gap-1 pt-0.5 text-xs font-medium text-white sm:pt-1">
+                {requestData.type !== 'book' && (
+                  <MediaTypeBadge
+                    mediaType={
+                      getMediaTypeBadgeType(requestData.type) ?? 'movie'
+                    }
+                    variant="compact"
+                  />
+                )}
+                {requestData.type !== 'book' && requestData.is4k && (
+                  <Badge badgeType="warning">4K</Badge>
+                )}
+                <span>
+                  {(isMovie(title)
                     ? title.releaseDate
-                    : isBook(title)
-                      ? title.firstPublishYear?.toString()
-                      : title.firstAirDate
-                )?.slice(0, 4)}
+                    : isMusic(title)
+                      ? title.releaseDate
+                      : isBook(title)
+                        ? title.firstPublishYear?.toString()
+                        : title.firstAirDate
+                  )?.slice(0, 4)}
+                </span>
               </div>
               <Link
                 href={getRequestDetailHref(requestData)}

--- a/src/components/RequestStatus/index.tsx
+++ b/src/components/RequestStatus/index.tsx
@@ -7,6 +7,9 @@ import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import Header from '@app/components/Common/Header';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge, {
+  type MediaTypeBadgeType,
+} from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import useToasts from '@app/hooks/useToasts';
 import { Permission, useUser } from '@app/hooks/useUser';
@@ -437,6 +440,15 @@ const getMediaBadge = (
   return intl.formatMessage(messages.book);
 };
 
+const getMediaBadgeType = (
+  item: RequestStatusItem
+): MediaTypeBadgeType | undefined => {
+  if (item.request.type === 'movie') return 'movie';
+  if (item.request.type === 'tv') return 'tv';
+  if (item.request.type === 'music') return 'album';
+  return undefined;
+};
+
 const getMediaFormat = (
   intl: ReturnType<typeof useIntl>,
   item: RequestStatusItem
@@ -715,9 +727,10 @@ const RequestStatusCard = ({
               {bookFormat ? (
                 <BookFormatBadge format={bookFormat} variant="compact" />
               ) : (
-                <span className="inline-flex min-h-4 items-center rounded-full bg-indigo-600 px-1.5 text-[11px] font-semibold leading-[1.3] text-indigo-50">
-                  {getMediaBadge(intl, item)}
-                </span>
+                <MediaTypeBadge
+                  mediaType={getMediaBadgeType(item) ?? 'movie'}
+                  variant="compact"
+                />
               )}
               <dl className="mt-0.5 grid grid-cols-[max-content_minmax(0,1fr)] gap-x-2 gap-y-0.5">
                 <dt className="font-medium text-gray-100">

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -5,6 +5,7 @@ import BookFormatBadge, {
 } from '@app/components/Common/BookFormatBadge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import StatusBadgeMini from '@app/components/Common/StatusBadgeMini';
 import Tooltip from '@app/components/Common/Tooltip';
 import ErrorCard from '@app/components/TitleCard/ErrorCard';
@@ -562,27 +563,11 @@ const TitleCard = ({
                   className="pointer-events-none z-40 self-start"
                 />
               ) : (
-                <div
-                  className={`pointer-events-none z-40 self-start rounded-full border shadow-md ${
-                    mediaType === 'movie' || mediaType === 'collection'
-                      ? 'border-blue-500 bg-blue-600/80'
-                      : isAlbum
-                        ? 'border-emerald-500 bg-emerald-600/80'
-                        : 'border-purple-600 bg-purple-600/80'
-                  }`}
-                >
-                  <div className="flex h-4 items-center px-2 py-2 text-center text-xs font-medium text-white sm:h-5">
-                    {mediaType === 'movie'
-                      ? intl.formatMessage(globalMessages.movie)
-                      : mediaType === 'collection'
-                        ? intl.formatMessage(globalMessages.collection)
-                        : mediaType === 'tv'
-                          ? intl.formatMessage(globalMessages.tvshow)
-                          : isAlbum
-                            ? intl.formatMessage(globalMessages.album)
-                            : intl.formatMessage(globalMessages.artist)}
-                  </div>
-                </div>
+                <MediaTypeBadge
+                  mediaType={mediaType === 'person' ? 'artist' : mediaType}
+                  variant="card"
+                  className="pointer-events-none z-40 self-start"
+                />
               )}
               {currentStatus !== MediaStatus.BLOCKLISTED && (
                 <div className="z-40 flex items-center">

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -9,6 +9,7 @@ import Badge from '@app/components/Common/Badge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import MediaTypeBadge from '@app/components/Common/MediaTypeBadge';
 import PageTitle from '@app/components/Common/PageTitle';
 import type { PlayButtonLink } from '@app/components/Common/PlayButton';
 import PlayButton from '@app/components/Common/PlayButton';
@@ -581,6 +582,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
         </div>
         <div className="media-title">
           <div className="media-status">
+            <MediaTypeBadge mediaType="tv" variant="inline" />
             <StatusBadge
               status={data.mediaInfo?.status}
               downloadItem={data.mediaInfo?.downloadStatus}

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -1,11 +1,13 @@
 import useToasts from '@app/hooks/useToasts';
 import globalMessages from '@app/i18n/globalMessages';
+import { readDiscoverScrollEntry } from '@app/utils/discoverScrollRestoration';
 import {
   setPersistentResponse,
   usePersistentResponse,
 } from '@app/utils/swrCache';
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import { buildDiscoverQueryString } from '@server/utils/discoverQuery';
+import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import useSWRInfinite from 'swr/infinite';
@@ -46,6 +48,7 @@ interface DiscoverResult<T, S> {
   isReachingEnd: boolean;
   error: unknown;
   titles: T[];
+  shuffleSeed: string;
   firstResultData?: BaseSearchResult<T> & S;
   mutate?: () => void;
 }
@@ -149,7 +152,11 @@ const useDiscover = <
   const { hasPermission, user } = useUser();
   const { addToast } = useToasts();
   const intl = useIntl();
-  const [shuffleSeed, setShuffleSeed] = useState(getShuffleSeed);
+  const router = useRouter();
+  const [shuffleSeed, setShuffleSeed] = useState(
+    () =>
+      readDiscoverScrollEntry(router.asPath)?.shuffleSeed ?? getShuffleSeed()
+  );
   const fallbackCacheKey = useMemo(
     () =>
       `discover-view:${user?.id ?? 'anonymous'}:${endpoint}:${buildDiscoverQueryString(
@@ -159,7 +166,7 @@ const useDiscover = <
   );
   const persistentFallbackData =
     usePersistentResponse<(BaseSearchResult<T> & S)[]>(fallbackCacheKey);
-  // A randomized view gets a new seed on each mount. Restoring results produced
+  // A randomized view gets a new seed on fresh visits. Restoring results produced
   // with the previous seed would paint one lineup and then replace it as soon as
   // the current request completes.
   const fallbackData = randomizeOrder ? undefined : persistentFallbackData;
@@ -355,6 +362,7 @@ const useDiscover = <
     isReachingEnd,
     error: error && titles.length ? null : error,
     titles,
+    shuffleSeed,
     firstResultData: data?.[0],
     mutate,
   };

--- a/src/hooks/useDiscoverScrollRestoration.test.ts
+++ b/src/hooks/useDiscoverScrollRestoration.test.ts
@@ -1,0 +1,130 @@
+import { readDiscoverScrollEntry } from '@app/utils/discoverScrollRestoration';
+import { JSDOM } from 'jsdom';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import type { NextRouter } from 'next/router';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import useDiscoverScrollRestoration from './useDiscoverScrollRestoration';
+
+describe('discover Back navigation', () => {
+  for (const [tab, mediaType] of [
+    ['movies', 'movie'],
+    ['tv', 'tv'],
+    ['books', 'book'],
+  ] as const) {
+    it(`restores ${tab} after Next replaces history state and cached pages load`, async () => {
+      const path = `/discover/${tab}`;
+      const dom = new JSDOM('<div id="root"></div>', {
+        url: `http://localhost${path}`,
+      });
+      const globals = ['window', 'document', 'IS_REACT_ACT_ENVIRONMENT'];
+      const descriptors = globals.map((name) =>
+        Object.getOwnPropertyDescriptor(globalThis, name)
+      );
+      Object.defineProperties(globalThis, {
+        window: { configurable: true, value: dom.window },
+        document: { configurable: true, value: dom.window.document },
+        IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+      });
+      const frames = new Map<number, FrameRequestCallback>();
+      let frameId = 0;
+      dom.window.requestAnimationFrame = (callback) => {
+        frames.set(++frameId, callback);
+        return frameId;
+      };
+      dom.window.cancelAnimationFrame = (id) => {
+        frames.delete(id);
+      };
+      const scrolls: unknown[] = [];
+      dom.window.scrollTo = (...args: unknown[]) => {
+        scrolls.push(args);
+      };
+      const listeners = new Set<(url: string) => void>();
+      const router = {
+        asPath: path,
+        isReady: true,
+        events: {
+          on: (_event: string, callback: (url: string) => void) =>
+            listeners.add(callback),
+          off: (_event: string, callback: (url: string) => void) =>
+            listeners.delete(callback),
+        },
+      } as unknown as NextRouter;
+      let itemCount = 80;
+      let requests = 0;
+      const fetchMore = () => {
+        requests++;
+      };
+      const Probe = () => {
+        useDiscoverScrollRestoration({
+          mediaType,
+          shuffleSeed: 'original-order',
+          itemCount,
+          isLoading: false,
+          isReachingEnd: false,
+          fetchMore,
+        });
+        return null;
+      };
+      const root = createRoot(dom.window.document.getElementById('root')!);
+      const render = () =>
+        act(async () => {
+          root.render(
+            createElement(
+              RouterContext.Provider,
+              { value: router },
+              createElement(Probe)
+            )
+          );
+        });
+      const flushFrame = () =>
+        act(async () => {
+          const callbacks = [...frames.values()];
+          frames.clear();
+          callbacks.forEach((callback) => callback(0));
+        });
+      try {
+        dom.window.history.replaceState({ key: 'list', __N: true }, '', path);
+        await render();
+        Object.defineProperty(dom.window, 'scrollY', { value: 4200 });
+        listeners.forEach((listener) => listener(`/${mediaType}/123`));
+        deepStrictEqual(readDiscoverScrollEntry(path), {
+          path,
+          scrollY: 4200,
+          itemCount: 80,
+          shuffleSeed: 'original-order',
+        });
+        await act(async () => root.render(null));
+        strictEqual(listeners.size, 0);
+        // Next's Back handler replaces the state before mounting the list.
+        dom.window.history.replaceState({ key: 'list', __N: true }, '', path);
+        itemCount = 20;
+        await render();
+        strictEqual(requests, 1);
+        strictEqual(scrolls.length, 0);
+        // SWR can serve subsequent pages from cache without a loading render.
+        itemCount = 40;
+        await render();
+        strictEqual(requests, 2);
+        itemCount = 80;
+        await render();
+        await flushFrame();
+        strictEqual(scrolls.length, 0);
+        await flushFrame();
+        deepStrictEqual(scrolls, [[{ top: 4200, left: 0, behavior: 'auto' }]]);
+        await render();
+        strictEqual(frames.size, 0);
+      } finally {
+        await act(async () => root.unmount());
+        dom.window.close();
+        globals.forEach((name, index) => {
+          const descriptor = descriptors[index];
+          if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+          else Reflect.deleteProperty(globalThis, name);
+        });
+      }
+    });
+  }
+});

--- a/src/hooks/useDiscoverScrollRestoration.ts
+++ b/src/hooks/useDiscoverScrollRestoration.ts
@@ -1,15 +1,16 @@
 import type { RestorableDiscoverMediaType } from '@app/utils/discoverScrollRestoration';
 import {
-  DISCOVER_SCROLL_HISTORY_KEY,
-  getDiscoverScrollEntry,
   getScrollRestorationAction,
   isMediaDetailPath,
+  readDiscoverScrollEntry,
+  saveDiscoverScrollEntry,
 } from '@app/utils/discoverScrollRestoration';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 
 type UseDiscoverScrollRestorationOptions = {
   mediaType: RestorableDiscoverMediaType;
+  shuffleSeed?: string;
   itemCount: number;
   isLoading: boolean;
   isReachingEnd: boolean;
@@ -18,6 +19,7 @@ type UseDiscoverScrollRestorationOptions = {
 
 const useDiscoverScrollRestoration = ({
   mediaType,
+  shuffleSeed,
   itemCount,
   isLoading,
   isReachingEnd,
@@ -25,11 +27,11 @@ const useDiscoverScrollRestoration = ({
 }: UseDiscoverScrollRestorationOptions): void => {
   const router = useRouter();
   const itemCountRef = useRef(itemCount);
-  const loadRequestedRef = useRef(false);
+  const loadRequestedRef = useRef<number | undefined>(undefined);
   const [entry, setEntry] = useState(() =>
     typeof window === 'undefined'
       ? undefined
-      : getDiscoverScrollEntry(window.history.state, router.asPath)
+      : readDiscoverScrollEntry(router.asPath)
   );
 
   itemCountRef.current = itemCount;
@@ -39,7 +41,7 @@ const useDiscoverScrollRestoration = ({
       return;
     }
 
-    setEntry(getDiscoverScrollEntry(window.history.state, router.asPath));
+    setEntry(readDiscoverScrollEntry(router.asPath));
   }, [router.asPath, router.isReady]);
 
   useEffect(() => {
@@ -48,33 +50,22 @@ const useDiscoverScrollRestoration = ({
         return;
       }
 
-      const currentState =
-        window.history.state && typeof window.history.state === 'object'
-          ? window.history.state
-          : {};
-
-      window.history.replaceState(
-        {
-          ...currentState,
-          [DISCOVER_SCROLL_HISTORY_KEY]: {
-            path: router.asPath,
-            scrollY: window.scrollY,
-            itemCount: itemCountRef.current,
-          },
-        },
-        '',
-        window.location.href
-      );
+      saveDiscoverScrollEntry({
+        path: router.asPath,
+        scrollY: window.scrollY,
+        itemCount: itemCountRef.current,
+        shuffleSeed,
+      });
     };
 
     router.events.on('routeChangeStart', saveScrollPosition);
 
     return () => router.events.off('routeChangeStart', saveScrollPosition);
-  }, [mediaType, router.asPath, router.events]);
+  }, [mediaType, router.asPath, router.events, shuffleSeed]);
 
   useEffect(() => {
     if (isLoading) {
-      loadRequestedRef.current = false;
+      loadRequestedRef.current = undefined;
       return;
     }
 
@@ -86,8 +77,8 @@ const useDiscoverScrollRestoration = ({
     });
 
     if (action === 'load-more') {
-      if (!loadRequestedRef.current) {
-        loadRequestedRef.current = true;
+      if (loadRequestedRef.current !== itemCount) {
+        loadRequestedRef.current = itemCount;
         fetchMore();
       }
 
@@ -98,21 +89,18 @@ const useDiscoverScrollRestoration = ({
       return;
     }
 
-    const currentState =
-      window.history.state && typeof window.history.state === 'object'
-        ? { ...window.history.state }
-        : {};
-    delete currentState[DISCOVER_SCROLL_HISTORY_KEY];
-    window.history.replaceState(currentState, '', window.location.href);
-
+    let secondFrame: number;
     const firstFrame = window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
         window.scrollTo({ top: entry.scrollY, left: 0, behavior: 'auto' });
         setEntry(undefined);
       });
     });
 
-    return () => window.cancelAnimationFrame(firstFrame);
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
   }, [entry, fetchMore, isLoading, isReachingEnd, itemCount]);
 };
 

--- a/src/hooks/useDiscoverScrollRestoration.ts
+++ b/src/hooks/useDiscoverScrollRestoration.ts
@@ -89,7 +89,7 @@ const useDiscoverScrollRestoration = ({
       return;
     }
 
-    let secondFrame: number;
+    let secondFrame: number | undefined;
     const firstFrame = window.requestAnimationFrame(() => {
       secondFrame = window.requestAnimationFrame(() => {
         window.scrollTo({ top: entry.scrollY, left: 0, behavior: 'auto' });
@@ -99,7 +99,9 @@ const useDiscoverScrollRestoration = ({
 
     return () => {
       window.cancelAnimationFrame(firstFrame);
-      window.cancelAnimationFrame(secondFrame);
+      if (secondFrame !== undefined) {
+        window.cancelAnimationFrame(secondFrame);
+      }
     };
   }, [entry, fetchMore, isLoading, isReachingEnd, itemCount]);
 };

--- a/src/utils/discoverScrollRestoration.test.ts
+++ b/src/utils/discoverScrollRestoration.test.ts
@@ -5,6 +5,8 @@ import {
   getDiscoverScrollEntry,
   getScrollRestorationAction,
   isMediaDetailPath,
+  readDiscoverScrollEntry,
+  saveDiscoverScrollEntry,
 } from './discoverScrollRestoration';
 
 describe('discover scroll restoration', () => {
@@ -68,5 +70,53 @@ describe('discover scroll restoration', () => {
       }),
       'restore'
     );
+  });
+});
+
+describe('history entry persistence', () => {
+  it('retains the list seed and offset after Next replaces history state, isolating fresh visits', () => {
+    const values = new Map<string, string>();
+    const originalWindow = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'window'
+    );
+    const browser = {
+      history: { state: { key: 'first' } },
+      sessionStorage: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+      },
+    };
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: browser,
+    });
+    try {
+      for (const path of [
+        '/discover/movies',
+        '/discover/tv',
+        '/discover/books',
+      ]) {
+        const entry = {
+          path,
+          scrollY: 4200,
+          itemCount: 80,
+          shuffleSeed: 'original-order',
+        };
+        browser.history.state = { key: path };
+        saveDiscoverScrollEntry(entry);
+        browser.history.state = { key: 'detail' };
+        strictEqual(readDiscoverScrollEntry(path), undefined);
+        browser.history.state = { key: path };
+        deepStrictEqual(readDiscoverScrollEntry(path), entry);
+        strictEqual(readDiscoverScrollEntry(`${path}?sortBy=new`), undefined);
+        browser.history.state = { key: 'fresh-visit' };
+        strictEqual(readDiscoverScrollEntry(path), undefined);
+      }
+    } finally {
+      if (originalWindow)
+        Object.defineProperty(globalThis, 'window', originalWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+    }
   });
 });

--- a/src/utils/discoverScrollRestoration.test.ts
+++ b/src/utils/discoverScrollRestoration.test.ts
@@ -27,6 +27,18 @@ describe('discover scroll restoration', () => {
     const state = { [DISCOVER_SCROLL_HISTORY_KEY]: entry };
 
     deepStrictEqual(getDiscoverScrollEntry(state, entry.path), entry);
+    deepStrictEqual(
+      getDiscoverScrollEntry(
+        {
+          [DISCOVER_SCROLL_HISTORY_KEY]: {
+            ...entry,
+            shuffleSeed: 'x'.repeat(128),
+          },
+        },
+        entry.path
+      ),
+      { ...entry, shuffleSeed: 'x'.repeat(128) }
+    );
     strictEqual(getDiscoverScrollEntry(state, '/discover/movies'), undefined);
     strictEqual(
       getDiscoverScrollEntry(
@@ -34,6 +46,18 @@ describe('discover scroll restoration', () => {
           [DISCOVER_SCROLL_HISTORY_KEY]: {
             ...entry,
             scrollY: Number.NaN,
+          },
+        },
+        entry.path
+      ),
+      undefined
+    );
+    strictEqual(
+      getDiscoverScrollEntry(
+        {
+          [DISCOVER_SCROLL_HISTORY_KEY]: {
+            ...entry,
+            shuffleSeed: 'x'.repeat(129),
           },
         },
         entry.path

--- a/src/utils/discoverScrollRestoration.ts
+++ b/src/utils/discoverScrollRestoration.ts
@@ -4,6 +4,7 @@ export type DiscoverScrollEntry = {
   path: string;
   scrollY: number;
   itemCount: number;
+  shuffleSeed?: string;
 };
 
 export const DISCOVER_SCROLL_HISTORY_KEY = '__seerrDiscoverScroll';
@@ -76,4 +77,42 @@ export const getScrollRestorationAction = ({
   }
 
   return isLoading ? 'none' : 'load-more';
+};
+
+// Next.js replaces history.state during Back/Forward navigation, but retains key.
+const storageKey = (): string | undefined => {
+  const key = window.history.state?.key;
+  return typeof key === 'string'
+    ? `${DISCOVER_SCROLL_HISTORY_KEY}:${key}`
+    : undefined;
+};
+
+export const readDiscoverScrollEntry = (
+  path: string
+): DiscoverScrollEntry | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const key = storageKey();
+    return key
+      ? getDiscoverScrollEntry(
+          {
+            [DISCOVER_SCROLL_HISTORY_KEY]: JSON.parse(
+              window.sessionStorage.getItem(key) ?? 'null'
+            ),
+          },
+          path
+        )
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const saveDiscoverScrollEntry = (entry: DiscoverScrollEntry): void => {
+  try {
+    const key = storageKey();
+    if (key) window.sessionStorage.setItem(key, JSON.stringify(entry));
+  } catch {
+    // Navigation must still work when session storage is unavailable.
+  }
 };

--- a/src/utils/discoverScrollRestoration.ts
+++ b/src/utils/discoverScrollRestoration.ts
@@ -9,6 +9,9 @@ export type DiscoverScrollEntry = {
 
 export const DISCOVER_SCROLL_HISTORY_KEY = '__seerrDiscoverScroll';
 
+// Keep persisted seeds within the same bound enforced by the discover APIs.
+const MAX_SHUFFLE_SEED_LENGTH = 128;
+
 const detailPathPatterns: Record<RestorableDiscoverMediaType, RegExp> = {
   movie: /^\/movie\/[^/?#]+(?:[/?#]|$)/,
   tv: /^\/tv\/[^/?#]+(?:[/?#]|$)/,
@@ -49,7 +52,10 @@ export const getDiscoverScrollEntry = (
     candidate.scrollY < 0 ||
     typeof candidate.itemCount !== 'number' ||
     !Number.isInteger(candidate.itemCount) ||
-    candidate.itemCount < 0
+    candidate.itemCount < 0 ||
+    (candidate.shuffleSeed !== undefined &&
+      (typeof candidate.shuffleSeed !== 'string' ||
+        candidate.shuffleSeed.length > MAX_SHUFFLE_SEED_LENGTH))
   ) {
     return undefined;
   }


### PR DESCRIPTION
## Description

Returning from details to Movies, Series, or Books could lose the list order and scroll position. Store the restoration snapshot in session storage using Next.js's history-entry key, preserve the shuffle seed, and load enough results before restoring the offset. Fresh visits and different filters remain separate.

The restoration hook also handles cached page loads without waiting for a loading-state transition and cancels both animation frames when it unmounts.

Includes a separate formatting-only commit for an existing container-security test assertion that failed the full format check.

**AI Disclosure:** Codex generated the implementation, regression tests, release note, and this PR description and ran the automated checks. Manual browser verification has not been performed.

## How Has This Been Tested?

- [GitHub Cypress run on ac80cfeb](https://github.com/snapetech/seerrng/actions/runs/34071108069) passed: all 19 specs, 75 tests passed, 32 live-only tests pending, 0 failed.

- Updated branch `ac80cfeb`: all **19 Cypress specs passed locally (75 passed, 32 live-only tests pending, 0 failed)** against a freshly seeded production build. Corrected stale format labels, modal controls, and book manage URLs; additionally verified format selection updates the request title.
- Revalidated the integrated branch after maintainer updates: full build, lint, application and Cypress typechecks, formatting, and all 7 focused scroll-restoration tests passed.

- Full application test suite: **1,771 passed, 4 skipped, 0 failed** — `TMPDIR=/private/tmp pnpm test` (macOS, Node 22.23.1; canonical temporary path required by symlink-security tests).
- Hook regression tests simulate list → detail → Back for Movies, Series, and Books, Next.js history-state replacement, cached pagination, and delayed scroll restoration.
- Storage regression coverage checks preserved list seeds, distinct history entries, and filter isolation.
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm format:check`.
- `pnpm test:tooling`: 128 tests passed in the existing local Linux CI image; this suite requires GNU/Linux utilities.
- i18n validation, workflow boundaries, browser/server security boundaries, and attribution checks.
- `pnpm release-notes:preview --base origin/main --head HEAD`.

## Screenshots / Logs (if applicable)

Automated navigation coverage uses React and JSDOM; the full Cypress suite was also run locally in Electron. Production browser behavior has not been verified.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note. (Not applicable.)
The fragment includes audience, area, action, and breaking-change status. I previewed the release text with `pnpm release-notes:preview`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI.
- [x] I have updated the documentation accordingly (release note).
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`.
- [x] Translation validation passed; no translation keys changed.
- [x] Database migration: not required.



