### PR TITLE
fix(discover): keep poster rows stable on back navigation

### DIFF
--- a/cypress/e2e/discover-scroll.cy.ts
+++ b/cypress/e2e/discover-scroll.cy.ts
@@ -1,0 +1,210 @@
+const listItems = '.cards-vertical > li';
+const targetIndex = 74;
+const pageSize = 20;
+const resultCount = 120;
+
+const mockDiscovery = (tab: string, mediaType: string) => {
+  const results = Array.from({ length: resultCount }, (_, index) => ({
+    id: mediaType === 'book' ? `OLSCROLL${index + 1}W` : 900000 + index,
+    mediaType,
+    title: `Scroll ${mediaType} ${index + 1}`,
+    name: `Scroll ${mediaType} ${index + 1}`,
+    author: 'Scroll Author',
+    overview: 'A deterministic discovery result for scroll restoration.',
+    releaseDate: '2026-01-01',
+    firstAirDate: '2026-01-01',
+    firstPublishYear: 2026,
+    posterPath: null,
+  }));
+
+  cy.intercept('GET', `/api/v1/discover/${tab}*`, (req) => {
+    const page = Number(new URL(req.url).searchParams.get('page') ?? 1);
+    req.reply({
+      page,
+      totalPages: resultCount / pageSize,
+      totalResults: resultCount,
+      results: results.slice((page - 1) * pageSize, page * pageSize),
+    });
+  }).as('discoveryPage');
+
+  return results;
+};
+
+// Let Chromium paint the newly visited row so content-visibility has recorded
+// its real size before we move farther down the list.
+const paintVisitedRow = () =>
+  cy.window().then(
+    (win) =>
+      new Cypress.Promise<void>((resolve) => {
+        win.requestAnimationFrame(() => {
+          win.requestAnimationFrame(() => resolve());
+        });
+      })
+  );
+
+const browseToTarget = () => {
+  // Visit every row on the way down, as a person browsing does. Jumping
+  // straight to the target leaves earlier rows at their estimated height
+  // on both visits and misses the regression.
+  for (let index = 4; index <= targetIndex; index += 5) {
+    cy.get(listItems)
+      .eq(index)
+      .find('[data-testid=title-card]')
+      .should('exist');
+    cy.get(listItems)
+      .eq(index)
+      .scrollIntoView({ offset: { top: -300, left: 0 } });
+    paintVisitedRow();
+    cy.get(listItems)
+      .eq(index)
+      .should(($item) => {
+        const bounds = $item[0].getBoundingClientRect();
+        expect(bounds.top).to.be.at.least(0);
+        expect(bounds.bottom).to.be.at.most(900);
+        expect(bounds.height).to.be.closeTo(bounds.width * 1.5, 2);
+      });
+  }
+};
+
+describe('Discover Back navigation geometry', () => {
+  beforeEach(() => {
+    cy.viewport(1440, 900);
+    cy.loginAsAdmin();
+  });
+
+  [
+    { tab: 'movies', mediaType: 'movie' },
+    { tab: 'tv', mediaType: 'tv' },
+    { tab: 'books', mediaType: 'book' },
+  ].forEach(({ tab, mediaType }) => {
+    it(`returns to the same ${tab} card and viewport position after visiting details`, () => {
+      const results = mockDiscovery(tab, mediaType);
+      const target = results[targetIndex];
+      const detailPath = `/${mediaType}/${target.id}`;
+      let beforeTop = 0;
+      let beforeOrder: string[] = [];
+
+      cy.intercept('GET', `/api/v1${detailPath}/*`, {
+        page: 1,
+        totalPages: 1,
+        totalResults: 0,
+        results: [],
+      });
+      const details = {
+        ...target,
+        credits: { cast: [], crew: [] },
+        productionCompanies: [],
+        productionCountries: [],
+        spokenLanguages: [],
+        genres: [],
+        keywords: [],
+        relatedVideos: [],
+        externalIds: {},
+        releases: { results: [] },
+        contentRatings: { results: [] },
+        seasons: [],
+        createdBy: [],
+        episodeRunTime: [],
+        networks: [],
+        isbnCandidates: [],
+        subjects: [],
+        originalLanguage: 'en',
+        status: 'Released',
+      };
+      cy.intercept('GET', `/api/v1${detailPath}`, details).as('details');
+      if (mediaType !== 'book') {
+        // Video detail pages also fetch on the server. Stub the Next data
+        // response so the synthetic ID never depends on an upstream title.
+        cy.intercept('GET', `**/_next/data/*${detailPath}.json*`, {
+          pageProps: { [mediaType]: details },
+          __N_SSP: true,
+        });
+      }
+
+      cy.visit(`/discover/${tab}`);
+      cy.wait('@discoveryPage');
+
+      browseToTarget();
+
+      cy.get(`${listItems} a[href="${detailPath}"]`).should('be.visible');
+      cy.get(`${listItems} a`).then(($links) => {
+        beforeOrder = $links
+          .toArray()
+          .map((link) => link.getAttribute('href') ?? '');
+      });
+      // Measure the outer li: the inner card can scale when hovered. Disable
+      // Cypress's automatic click scrolling so the measurement is unchanged.
+      cy.get(listItems)
+        .eq(targetIndex)
+        .then(($item) => {
+          beforeTop = $item[0].getBoundingClientRect().top;
+        });
+      cy.get(`${listItems} a[href="${detailPath}"]`).click({
+        scrollBehavior: false,
+      });
+      cy.wait('@details');
+      cy.location('pathname').should('eq', detailPath);
+      cy.get('[data-testid=media-title]').should('contain', target.title);
+
+      cy.go('back');
+      cy.location('pathname').should('eq', `/discover/${tab}`);
+      cy.get(`${listItems} a`).should(($links) => {
+        const afterOrder = $links
+          .toArray()
+          .map((link) => link.getAttribute('href') ?? '');
+        expect(afterOrder.slice(0, beforeOrder.length)).to.deep.eq(beforeOrder);
+      });
+      // Do not scroll the target into view here: Back must restore it itself.
+      cy.get(listItems)
+        .eq(targetIndex)
+        .should(($item) => {
+          expect($item.find(`a[href="${detailPath}"]`)).to.have.length(1);
+          expect($item[0].getBoundingClientRect().top).to.be.closeTo(
+            beforeTop,
+            2
+          );
+        });
+    });
+  });
+
+  it('updates remembered offscreen row heights when the column count changes', () => {
+    mockDiscovery('movies', 'movie');
+    cy.visit('/discover/movies');
+    cy.wait('@discoveryPage');
+    browseToTarget();
+
+    let previousColumns = 0;
+    cy.get('.cards-vertical').then(($grid) => {
+      previousColumns = getComputedStyle($grid[0]).gridTemplateColumns.split(
+        ' '
+      ).length;
+    });
+
+    [900, 1600].forEach((width) => {
+      cy.viewport(width, 900);
+      paintVisitedRow();
+      cy.get('.cards-vertical')
+        .should(($grid) => {
+          const columns = getComputedStyle($grid[0]).gridTemplateColumns.split(
+            ' '
+          ).length;
+          expect(columns).not.to.eq(previousColumns);
+        })
+        .then(($grid) => {
+          previousColumns = getComputedStyle(
+            $grid[0]
+          ).gridTemplateColumns.split(' ').length;
+        });
+      // The first row was painted while browsing but is now far offscreen.
+      // Its remembered height must not prevent it shrinking to the new width.
+      // Reading only the outer li does not force its skipped content to render.
+      cy.get(listItems)
+        .first()
+        .should(($item) => {
+          const bounds = $item[0].getBoundingClientRect();
+          expect(bounds.bottom).to.be.lessThan(0);
+          expect(bounds.height).to.be.closeTo(bounds.width * 1.5, 2);
+        });
+    });
+  });
+});

--- a/cypress/e2e/readme-screenshots.cy.ts
+++ b/cypress/e2e/readme-screenshots.cy.ts
@@ -116,12 +116,33 @@ const installMocks = () => {
 };
 
 const waitForImages = () => {
-  cy.get('[data-testid=title-card] img:visible')
-    .should('have.length.greaterThan', 8)
-    .then({ timeout: 20000 }, ($images) => {
-      const images = ($images.toArray() as HTMLImageElement[]).filter(
-        (image) => image.currentSrc || image.src
+  const viewportImages = ($images: JQuery<HTMLElement>) =>
+    ($images.toArray() as HTMLImageElement[]).filter((image) => {
+      const bounds = image.getBoundingClientRect();
+      const viewport = image.ownerDocument.documentElement;
+
+      // jQuery's :visible also matches lazy images in offscreen sliders.
+      // Only await covers that can appear in the viewport screenshot.
+      return (
+        (image.currentSrc || image.src) &&
+        bounds.width > 0 &&
+        bounds.height > 0 &&
+        bounds.bottom > 0 &&
+        bounds.right > 0 &&
+        bounds.top < viewport.clientHeight &&
+        bounds.left < viewport.clientWidth
       );
+    });
+
+  cy.get('[data-testid=title-card] img:visible')
+    .should(($images) => {
+      expect(
+        viewportImages($images),
+        'covers in the screenshot viewport'
+      ).to.have.length.greaterThan(8);
+    })
+    .then({ timeout: 20000 }, ($images) => {
+      const images = viewportImages($images);
 
       return Cypress.Promise.all(
         images.map(

--- a/release-notes/fix-discover-back-row-position.md
+++ b/release-notes/fix-discover-back-row-position.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users
+area: discover
+action: none
+breaking: false
+---
+Returning from details to a discovery grid now keeps the same row in place, including when earlier poster rows are offscreen.

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -85,7 +85,8 @@ const publicStatusRateLimit = rateLimit({
   limit: 60,
   standardHeaders: true,
   legacyHeaders: false,
-  skip: () => process.env.NODE_ENV === 'test',
+  skip: () =>
+    process.env.NODE_ENV === 'test' || process.env.E2E_TESTS === 'true',
 });
 export const PUBLIC_BACKDROPS_RATE_LIMIT = {
   windowMs: 60 * 1000,

--- a/src/components/Common/ListView/index.tsx
+++ b/src/components/Common/ListView/index.tsx
@@ -312,7 +312,7 @@ const ListView = ({
           {emptyMessage ?? intl.formatMessage(globalMessages.noresults)}
         </div>
       )}
-      <ul className="cards-vertical">
+      <ul className="cards-vertical poster-grid">
         {plexCards}
         {itemCards}
         {isLoading && !isReachingEnd && placeholderCards}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -442,6 +442,14 @@
     contain-intrinsic-size: auto 20rem;
   }
 
+  /* Match the responsive poster height even before an offscreen card renders.
+   * A fixed estimate shifts rows when Back navigation remounts the list. */
+  ul.cards-vertical.poster-grid > li {
+    aspect-ratio: 2 / 3;
+    min-height: 0;
+    contain-intrinsic-size: auto none;
+  }
+
   ul.cards-horizontal > li {
     content-visibility: auto;
     contain-intrinsic-size: auto 14rem;


### PR DESCRIPTION
## Description

Returning from movie, series, or book details can move the discovery rows even when scroll position and list order are restored correctly. The grid reserves 320px for skipped cards, but responsive posters can be shorter. In the captured Hoppers example, remounting one offscreen row moves the card down 93.72px.

Size poster-grid rows from their 2:3 aspect ratio and clear their automatic minimum height so previously rendered rows also resize correctly. The rule is scoped to ListView; grids with captions retain their existing layout. Adds regressions for all three tabs and resizing across column counts. Follow-up to #107.

Repeated navigation in the complete browser suite also exposed two E2E harness problems: public status requests exhausted their budget, and screenshot setup waited for lazy images outside the viewport. Apply the existing E2E-only status exemption and wait for viewport images. Production rate limiting still returns 429 after 60 requests; request-supplied test flags cannot bypass it.

**AI Disclosure:** Codex assisted with investigation, code, tests, browser recordings, and this PR description.

## How Has This Been Tested?

- Local production builds of the original `47330370` and fixed `ed3d2990`; Playwright Chromium with deterministic catalog/detail fixtures and no injected CSS. Original Movies drift: 93.72px. Fixed Movies, Series, Books, and mobile Movies: 0px; card order preserved in every run.
- New Cypress regressions fail on the original implementation for all three tabs and pass on the fix. All four new cases also pass without retries, including offscreen row resizing.
- Full Cypress suite on `61b228e`: 82 passed, 32 live-only checks pending, zero failures across 21 specs; retries disabled.
- Final `pnpm test` on `61b228e`: 1,798 passing, 4 skipped, zero failures.
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm format:check`, and Cypress TypeScript check passed.
- Release-note preview passed.

## Screenshots / Logs (if applicable)

[Playwright evidence: screenshots, recordings, measurements, and reproduction script](https://github.com/EasyAsABC123/seerrng/tree/94d6940566e25c957c0a6cd75c9051e9a355afed)

| Fixed: before clicking Hoppers | Fixed: after Back |
| --- | --- |
| ![Before click](https://raw.githubusercontent.com/EasyAsABC123/seerrng/94d6940566e25c957c0a6cd75c9051e9a355afed/after-1-before-click.png) | ![After Back](https://raw.githubusercontent.com/EasyAsABC123/seerrng/94d6940566e25c957c0a6cd75c9051e9a355afed/after-3-after-back.png) |

Kubernetes remained on its production image; validation used local production builds.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [x] The fragment includes audience, area, action, and breaking-change status.
- [x] I previewed the release text with `pnpm release-notes:preview`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. Release-note fragment included.
- [x] All new and existing tests passed. Optional live checks and environment-specific unit skips are listed above.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` (no UI text changes)
- [ ] Database migration (if required) (not required)
