### PR TITLE
fix(images): reuse downloaded artwork across media pages

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -98,7 +98,9 @@ const getCacheControlDirectives = (response) =>
   new Set(
     (response?.headers.get('cache-control') ?? '')
       .split(',')
-      .map((directive) => directive.trim().toLowerCase().split('=', 1)[0])
+      .map((directive) =>
+        directive.trim().toLowerCase().split('=', 1)[0].trim()
+      )
       .filter(Boolean)
   );
 
@@ -133,6 +135,60 @@ const isFresh = (response, maxAgeMs) => {
       : maxAgeMs;
 
   return Date.now() - getCachedAt(response) < effectiveMaxAge;
+};
+
+const isPublicArtworkResponse = (request, response, cacheType) => {
+  const directives = getCacheControlDirectives(response);
+
+  return (
+    cacheType === 'static' &&
+    new URL(request.url).pathname.startsWith('/imageproxy/') &&
+    isRuntimeCacheableResponse(response) &&
+    /^image\//i.test(response.headers.get('content-type') ?? '') &&
+    directives.has('public') &&
+    !directives.has('private') &&
+    !directives.has('no-cache')
+  );
+};
+
+const isFreshArtwork = (response) => {
+  const now = Date.now();
+  const cachedAt = getCachedAt(response);
+  if (cachedAt <= 0 || cachedAt > now) {
+    return false;
+  }
+
+  let maxAgeMs = STATIC_CACHE_FRESH_MS;
+  const maxAgeDirectives = (response.headers.get('cache-control') ?? '')
+    .split(',')
+    .filter((directive) => /^\s*max-age\s*(?:=|$)/i.test(directive));
+
+  if (maxAgeDirectives.length > 0) {
+    // Malformed or conflicting freshness metadata cannot authorize a cache hit.
+    const match = maxAgeDirectives[0].match(
+      /^\s*max-age\s*=\s*(?:"(\d+)"|(\d+))\s*$/i
+    );
+    if (maxAgeDirectives.length !== 1 || !match) {
+      return false;
+    }
+    maxAgeMs = Math.min(maxAgeMs, Number(match[1] ?? match[2]) * 1000);
+  }
+
+  const ageHeader = response.headers.get('age');
+  if (ageHeader !== null && !/^\d+$/.test(ageHeader.trim())) {
+    return false;
+  }
+  const ageMs = Number(ageHeader ?? 0) * 1000;
+  const dateHeader = response.headers.get('date');
+  const responseDate = dateHeader === null ? cachedAt : Date.parse(dateHeader);
+  if (!Number.isFinite(ageMs) || !Number.isFinite(responseDate)) {
+    return false;
+  }
+
+  // A response may already be old when fetched from the browser/CDN cache.
+  // The worker's insertion timestamp must not reset that existing age.
+  const initialAgeMs = Math.max(0, cachedAt - responseDate, ageMs);
+  return initialAgeMs + (now - cachedAt) < maxAgeMs;
 };
 
 const addCacheTimestamp = (response) => {
@@ -341,6 +397,23 @@ const staleWhileRevalidate = async (request, cacheRequest, cacheType) => {
   const config = getCacheConfig(cacheType);
   const cache = await caches.open(config.cacheName);
   const cachedResponse = await cache.match(cacheRequest);
+  const publicArtwork = isPublicArtworkResponse(
+    request,
+    cachedResponse,
+    cacheType
+  );
+  const freshCachedResponse = publicArtwork
+    ? !['reload', 'no-cache', 'no-store'].includes(request.cache) &&
+      isFreshArtwork(cachedResponse)
+    : isFresh(cachedResponse, config.freshMs);
+
+  if (publicArtwork && freshCachedResponse) {
+    return {
+      responsePromise: Promise.resolve(cachedResponse),
+      networkResponsePromise: Promise.resolve(undefined),
+    };
+  }
+
   const networkResponsePromise = fetch(request)
     .then(async (networkResponse) => {
       if ([401, 403, 404, 410].includes(networkResponse.status)) {
@@ -352,7 +425,7 @@ const staleWhileRevalidate = async (request, cacheRequest, cacheType) => {
     .catch(() => undefined);
 
   const responsePromise =
-    cachedResponse && isFresh(cachedResponse, config.freshMs)
+    cachedResponse && freshCachedResponse
       ? Promise.resolve(cachedResponse)
       : networkResponsePromise.then((networkResponse) => {
           if (networkResponse && networkResponse.status < 500) {

--- a/release-notes/fixed-artwork-navigation-reuse.md
+++ b/release-notes/fixed-artwork-navigation-reuse.md
@@ -1,0 +1,8 @@
+---
+category: fixed
+audience: users
+area: artwork
+action: none
+breaking: false
+---
+Opening a title reuses downloaded artwork immediately, with sharper movie and TV posters loaded only when needed. Fresh cached covers avoid redundant background requests, and matching album covers share the same image URL across discovery and details.

--- a/server/api/coverartarchive/index.test.ts
+++ b/server/api/coverartarchive/index.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import dns from 'node:dns/promises';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 
 import CoverArtArchive from '@server/api/coverartarchive';
@@ -240,6 +241,12 @@ describe('CoverArtArchive metadata persistence', () => {
 });
 
 describe('CoverArtArchive redirect chain resolution', () => {
+  beforeEach(() => {
+    mock.method(dns, 'lookup', async () => [
+      { address: '93.184.216.34', family: 4 },
+    ]);
+  });
+
   afterEach(() => mock.restoreAll());
 
   it('follows Cover Art Archive through archive.org to its CDN subdomain', async () => {

--- a/server/api/coverartarchive/index.ts
+++ b/server/api/coverartarchive/index.ts
@@ -18,6 +18,7 @@ import {
 import axios from 'axios';
 import { In } from 'typeorm';
 import type { CoverArtResponse } from './interfaces';
+import { formatCoverArtArchiveThumbnailUrl } from './urls';
 
 const MAX_COVER_ART_IMAGES = 100;
 const MAX_COVER_ART_IDENTIFIER_LENGTH = 256;
@@ -205,9 +206,7 @@ class CoverArtArchive extends ExternalAPI {
           ? rawData.release.slice(0, MAX_COVER_ART_IDENTIFIER_LENGTH)
           : `/release/${albumId}`;
 
-      const releaseMBID = encodeURIComponent(
-        release.split('/').filter(Boolean).pop() ?? albumId
-      );
+      const releaseMBID = release.split('/').filter(Boolean).pop() ?? albumId;
       const images = (Array.isArray(rawData.images) ? rawData.images : [])
         .slice(0, MAX_COVER_ART_IMAGES)
         .flatMap((value) => {
@@ -220,8 +219,7 @@ class CoverArtArchive extends ExternalAPI {
             return [];
           }
 
-          const imageId = encodeURIComponent(String(id));
-          const fullUrl = `https://archive.org/download/mbid-${releaseMBID}/mbid-${releaseMBID}-${imageId}_thumb250.jpg`;
+          const fullUrl = formatCoverArtArchiveThumbnailUrl(releaseMBID, id);
 
           return [
             {

--- a/server/api/coverartarchive/urls.test.ts
+++ b/server/api/coverartarchive/urls.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  formatCoverArtArchiveThumbnailUrl,
+  getCoverArtArchiveThumbnailUrl,
+} from './urls';
+
+const releaseMbid = '55f7c1d9-b4f4-4c8d-a578-7d98687c4e45';
+
+describe('Cover Art Archive thumbnail URLs', () => {
+  it('uses the same archive object for known discovery and provider artwork', () => {
+    const expected = `https://archive.org/download/mbid-${releaseMbid}/mbid-${releaseMbid}-123_thumb250.jpg`;
+
+    assert.equal(getCoverArtArchiveThumbnailUrl(releaseMbid, 123), expected);
+    assert.equal(
+      formatCoverArtArchiveThumbnailUrl(releaseMbid, '123'),
+      expected
+    );
+  });
+
+  it('does not invent an archive object for invalid or missing identifiers', () => {
+    for (const imageId of [
+      undefined,
+      null,
+      '',
+      '123',
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+      '../123',
+    ]) {
+      assert.equal(
+        getCoverArtArchiveThumbnailUrl(releaseMbid, imageId),
+        undefined
+      );
+    }
+
+    for (const invalidRelease of [
+      undefined,
+      null,
+      '',
+      'release-not-a-uuid',
+      `../${releaseMbid}`,
+      `${releaseMbid}?version=2`,
+    ]) {
+      assert.equal(
+        getCoverArtArchiveThumbnailUrl(invalidRelease, 123),
+        undefined
+      );
+    }
+  });
+
+  it('preserves safe encoding of provider identifiers exactly once', () => {
+    assert.equal(
+      formatCoverArtArchiveThumbnailUrl('unsafe release', '../unsafe?value'),
+      'https://archive.org/download/mbid-unsafe%20release/mbid-unsafe%20release-..%2Funsafe%3Fvalue_thumb250.jpg'
+    );
+  });
+});

--- a/server/api/coverartarchive/urls.ts
+++ b/server/api/coverartarchive/urls.ts
@@ -1,0 +1,24 @@
+const RELEASE_MBID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const formatCoverArtArchiveThumbnailUrl = (
+  releaseMbid: string,
+  imageId: number | string
+): string => {
+  const encodedReleaseMbid = encodeURIComponent(releaseMbid);
+  const encodedImageId = encodeURIComponent(String(imageId));
+
+  return `https://archive.org/download/mbid-${encodedReleaseMbid}/mbid-${encodedReleaseMbid}-${encodedImageId}_thumb250.jpg`;
+};
+
+export const getCoverArtArchiveThumbnailUrl = (
+  releaseMbid: unknown,
+  imageId: unknown
+): string | undefined =>
+  typeof releaseMbid === 'string' &&
+  RELEASE_MBID_PATTERN.test(releaseMbid) &&
+  typeof imageId === 'number' &&
+  Number.isSafeInteger(imageId) &&
+  imageId > 0
+    ? formatCoverArtArchiveThumbnailUrl(releaseMbid, imageId)
+    : undefined;

--- a/server/constants/images.ts
+++ b/server/constants/images.ts
@@ -1,0 +1,4 @@
+// Share poster sizes with the client and cache warmers so navigation can reuse
+// the same uncropped artwork before requesting a higher-resolution variant.
+export const TMDB_POSTER_WIDTHS = [342, 500, 780] as const;
+export const TMDB_POSTER_BASE_SIZE = `w${TMDB_POSTER_WIDTHS[0]}`;

--- a/server/lib/imageCacheUrls.test.ts
+++ b/server/lib/imageCacheUrls.test.ts
@@ -3,6 +3,26 @@ import { describe, it } from 'node:test';
 
 import { extractImageCacheUrls } from './imageCacheUrls';
 
+describe('resolved poster warming', () => {
+  it('keeps provider URLs intact without turning local covers into TMDB paths', () => {
+    assert.deepEqual(
+      extractImageCacheUrls([
+        {
+          mediaType: 'tv',
+          posterPath: 'https://artworks.thetvdb.com/banners/poster.jpg',
+        },
+        { mediaType: 'movie', posterPath: '/api/v1/movie/1/cover' },
+        { mediaType: 'tv', posterPath: '/imageproxy/tvdb/banners/poster.jpg' },
+        {
+          mediaType: 'movie',
+          posterPath: '/images/seerr_poster_not_found.png',
+        },
+      ]),
+      ['https://artworks.thetvdb.com/banners/poster.jpg']
+    );
+  });
+});
+
 describe('extractImageCacheUrls', () => {
   it('extracts warmable image URLs from nested media responses', () => {
     const urls = extractImageCacheUrls({
@@ -47,7 +67,7 @@ describe('extractImageCacheUrls', () => {
     });
 
     assert.deepEqual(urls, [
-      'https://image.tmdb.org/t/p/w300_and_h450_face/movie.jpg',
+      'https://image.tmdb.org/t/p/w342/movie.jpg',
       'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/movie-backdrop.jpg',
       'https://coverartarchive.org/release/release-id/front-250',
       'https://covers.openlibrary.org/b/id/123-L.jpg',
@@ -76,9 +96,7 @@ describe('extractImageCacheUrls', () => {
       ],
     });
 
-    assert.deepEqual(urls, [
-      'https://image.tmdb.org/t/p/w300_and_h450_face/same.jpg',
-    ]);
+    assert.deepEqual(urls, ['https://image.tmdb.org/t/p/w342/same.jpg']);
   });
 
   it('ignores non-HTTP-like external image strings', () => {

--- a/server/lib/imageCacheUrls.ts
+++ b/server/lib/imageCacheUrls.ts
@@ -36,8 +36,15 @@ const getWarmableImageUrls = (item: ImageWarmableRecord): string[] => {
   const mediaType = typeof item.mediaType === 'string' ? item.mediaType : '';
 
   if (typeof item.posterPath === 'string') {
-    if (TMDB_POSTER_TYPES.has(mediaType) && item.posterPath.startsWith('/')) {
-      urls.push(getTmdbImageUrl(item.posterPath, 'w300_and_h450_face'));
+    const posterPath = item.posterPath;
+    if (
+      TMDB_POSTER_TYPES.has(mediaType) &&
+      posterPath.startsWith('/') &&
+      !['/api/', '/images/', '/imageproxy/'].some((prefix) =>
+        posterPath.startsWith(prefix)
+      )
+    ) {
+      urls.push(getTmdbImageUrl(posterPath, TMDB_POSTER_BASE_SIZE));
     } else {
       urls.push(normalizeExternalImageUrl(item.posterPath));
     }
@@ -106,3 +113,4 @@ export const extractImageCacheUrls = (body: unknown): string[] => {
 
   return [...urls];
 };
+import { TMDB_POSTER_BASE_SIZE } from '@server/constants/images';

--- a/server/routes/discover.test.ts
+++ b/server/routes/discover.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
 
+import CoverArtArchive from '@server/api/coverartarchive';
 import ExternalAPI from '@server/api/externalapi';
 import ListenBrainzAPI from '@server/api/listenbrainz';
 import MusicBrainz from '@server/api/musicbrainz';
@@ -864,6 +865,101 @@ describe('GET /discover/tv', () => {
 });
 
 describe('GET /discover/music', () => {
+  for (const sortBy of ['popular.week', 'release_date.desc']) {
+    it(`reuses detail cover URLs for ${sortBy} without additional artwork lookups`, async () => {
+      const releaseMbid = '55f7c1d9-b4f4-4c8d-a578-7d98687c4e45';
+      const albumId = 'f5093c06-23e3-404f-aeaa-40f72885ee3a';
+      const archive = new CoverArtArchive();
+      Object.defineProperty(archive, 'fetchReleaseGroupMetadata', {
+        value: async () => ({
+          release: `/release/${releaseMbid}`,
+          images: [{ id: 123, front: true, approved: true }],
+        }),
+      });
+      const detailArtwork = await archive.getCoverArt(albumId);
+      const getCoverArt = mock.method(
+        CoverArtArchive.prototype,
+        'getCoverArt',
+        async () => {
+          throw new Error('Discovery must not look up additional artwork');
+        }
+      );
+      const cases = [
+        {
+          imageId: 123,
+          releaseMbid,
+          expected: `https://archive.org/download/mbid-${releaseMbid}/mbid-${releaseMbid}-123_thumb250.jpg`,
+        },
+        ...[undefined, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1].map(
+          (imageId) => ({
+            imageId,
+            releaseMbid,
+            expected: `https://coverartarchive.org/release/${releaseMbid}/front-250`,
+          })
+        ),
+        {
+          imageId: 123,
+          releaseMbid: 'release-not-a-uuid',
+          expected:
+            'https://coverartarchive.org/release/release-not-a-uuid/front-250',
+        },
+        { imageId: 123, releaseMbid: '', expected: undefined },
+      ];
+      const albums = cases.map((entry, index) => ({
+        artist_mbids: [`artist-cover-${index}`],
+        artist_name: `Cover Artist ${index}`,
+        caa_id: entry.imageId as number,
+        caa_release_mbid: entry.releaseMbid,
+        listen_count: 100 - index,
+        release_group_mbid: index === 0 ? albumId : `album-cover-${index}`,
+        release_group_name: `Cover Album ${index}`,
+      }));
+      mock.method(ListenBrainzAPI.prototype, 'getTopAlbums', async () => ({
+        payload: {
+          count: albums.length,
+          from_ts: 0,
+          last_updated: 0,
+          offset: 0,
+          range: 'week',
+          release_groups: albums,
+          to_ts: 0,
+        },
+      }));
+      mock.method(ListenBrainzAPI.prototype, 'getFreshReleases', async () => ({
+        payload: {
+          releases: albums.map((album) => ({
+            ...album,
+            artist_credit_name: album.artist_name,
+            release_date: '2026-05-01',
+            release_group_primary_type: 'Album',
+            release_group_secondary_type: '',
+            release_mbid: album.caa_release_mbid,
+            release_name: album.release_group_name,
+            release_tags: [],
+          })),
+        },
+      }));
+
+      const agent = await login();
+      const res = await agent.get('/discover/music').query({ sortBy });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.body.results.length, cases.length);
+      for (const [index, entry] of cases.entries()) {
+        const album = res.body.results.find(
+          (result: { title: string }) => result.title === `Cover Album ${index}`
+        );
+        assert.equal(album?.posterPath, entry.expected);
+      }
+      assert.equal(
+        res.body.results.find((result: { id: string }) => result.id === albumId)
+          ?.posterPath,
+        detailArtwork.images[0]?.thumbnails[250]
+      );
+      assert.equal(getCoverArt.mock.callCount(), 0);
+    });
+  }
+
   it('rejects oversized music discovery queries before provider lookup', async () => {
     const searchAlbum = mock.method(MusicBrainz.prototype, 'searchAlbum');
     const getFreshReleases = mock.method(

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -1,3 +1,4 @@
+import { getCoverArtArchiveThumbnailUrl } from '@server/api/coverartarchive/urls';
 import { DEFAULT_EXTERNAL_API_TIMEOUT_MS } from '@server/api/externalapi';
 import ListenBrainzAPI from '@server/api/listenbrainz';
 import type {
@@ -507,9 +508,14 @@ const mapTopAlbumRelease = (releaseGroup: LbReleaseGroup): MbAlbumResult => ({
       },
     },
   ],
-  posterPath: releaseGroup.caa_release_mbid
-    ? `https://coverartarchive.org/release/${releaseGroup.caa_release_mbid}/front-250`
-    : undefined,
+  posterPath:
+    getCoverArtArchiveThumbnailUrl(
+      releaseGroup.caa_release_mbid,
+      releaseGroup.caa_id
+    ) ??
+    (releaseGroup.caa_release_mbid
+      ? `https://coverartarchive.org/release/${releaseGroup.caa_release_mbid}/front-250`
+      : undefined),
 });
 
 const mapFreshReleaseAlbum = (release: LbRelease): MbAlbumResult => ({
@@ -533,9 +539,11 @@ const mapFreshReleaseAlbum = (release: LbRelease): MbAlbumResult => ({
       },
     },
   ],
-  posterPath: release.caa_release_mbid
-    ? `https://coverartarchive.org/release/${release.caa_release_mbid}/front-250`
-    : undefined,
+  posterPath:
+    getCoverArtArchiveThumbnailUrl(release.caa_release_mbid, release.caa_id) ??
+    (release.caa_release_mbid
+      ? `https://coverartarchive.org/release/${release.caa_release_mbid}/front-250`
+      : undefined),
 });
 
 const mergeMusicAlbumMetadata = (

--- a/src/components/Association/helpers.ts
+++ b/src/components/Association/helpers.ts
@@ -49,7 +49,7 @@ export const nodeImage = (node: AssociationNode): string | undefined => {
   switch (node.mediaType) {
     case 'movie':
     case 'tv':
-      return getTmdbPosterImageUrl(node.posterPath, 'w300_and_h450_face');
+      return getTmdbPosterImageUrl(node.posterPath);
     case 'album':
       return node.posterPath ?? undefined;
     case 'artist':
@@ -57,9 +57,7 @@ export const nodeImage = (node: AssociationNode): string | undefined => {
     case 'book':
       return node.posterPath;
     case 'person':
-      return node.profilePath
-        ? `https://image.tmdb.org/t/p/w300_and_h450_face${node.profilePath}`
-        : undefined;
+      return getTmdbPosterImageUrl(node.profilePath, 'w600_and_h900_bestv2');
     default:
       return undefined;
   }

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -15,6 +15,10 @@ import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
 import { encodeApiPathSegment } from '@app/utils/apiPath';
 import defineMessages from '@app/utils/defineMessages';
+import {
+  getTmdbPosterImageUrl,
+  getTmdbPosterImageVariants,
+} from '@app/utils/imageCache';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
   ArrowDownTrayIcon,
@@ -355,9 +359,10 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
             type="tmdb"
             src={
               data.posterPath
-                ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+                ? getTmdbPosterImageUrl(data.posterPath)
                 : '/images/seerr_poster_not_found.png'
             }
+            variants={getTmdbPosterImageVariants(data.posterPath)}
             alt=""
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}

--- a/src/components/Common/CachedImage/index.tsx
+++ b/src/components/Common/CachedImage/index.tsx
@@ -1,3 +1,4 @@
+import useImageVariants from '@app/hooks/useImageVariants';
 import useSettings from '@app/hooks/useSettings';
 import type { CacheableImageType } from '@app/utils/imageCache';
 import {
@@ -6,6 +7,7 @@ import {
   getImageErrorFallback,
   getInitialImageUrl,
 } from '@app/utils/imageCache';
+import type { ImageVariant } from '@app/utils/loadedImages';
 import { UserIcon } from '@heroicons/react/24/solid';
 import type { ImageLoader, ImageProps } from 'next/image';
 import Image from 'next/image';
@@ -16,6 +18,7 @@ const imageLoader: ImageLoader = ({ src }) => src;
 export type CachedImageProps = ImageProps & {
   src: string;
   type: CacheableImageType;
+  variants?: readonly ImageVariant[];
 };
 
 /**
@@ -26,10 +29,12 @@ const CachedImage = memo(
   ({
     src,
     type,
+    variants,
     decoding = 'async',
     loading,
     priority,
     onError,
+    onLoad,
     ...props
   }: CachedImageProps) => {
     const { currentSettings } = useSettings();
@@ -42,6 +47,19 @@ const CachedImage = memo(
           type,
         }),
       [currentSettings.cacheImages, src, type]
+    );
+    const resolvedVariants = variants?.map((variant) => ({
+      ...variant,
+      src: getImageCacheUrl({
+        cacheImages: currentSettings.cacheImages,
+        src: variant.src,
+        type,
+      }),
+    }));
+    const progressiveImage = useImageVariants(
+      imageUrl,
+      resolvedVariants,
+      type !== 'avatar'
     );
     const [activeImageUrl, setActiveImageUrl] = useState(() =>
       getInitialImageUrl(type, imageUrl)
@@ -76,16 +94,25 @@ const CachedImage = memo(
       );
     }
 
+    const displayImageUrl =
+      type === 'avatar' ? activeImageUrl : progressiveImage.src;
+
     return (
       <Image
         unoptimized
         loader={imageLoader}
-        src={activeImageUrl}
+        src={displayImageUrl}
+        ref={progressiveImage.ref}
         decoding={decoding}
         loading={priority ? undefined : (loading ?? 'lazy')}
         priority={priority}
+        onLoad={(event) => {
+          if (type !== 'avatar') progressiveImage.onLoad(event.currentTarget);
+          onLoad?.(event);
+        }}
         onError={(event) => {
-          const fallbackImage = getImageErrorFallback(type, activeImageUrl);
+          if (type !== 'avatar') progressiveImage.onError(event.currentTarget);
+          const fallbackImage = getImageErrorFallback(type, displayImageUrl);
           if (fallbackImage) {
             setActiveImageUrl(fallbackImage);
           }

--- a/src/components/IssueDetails/index.tsx
+++ b/src/components/IssueDetails/index.tsx
@@ -19,6 +19,10 @@ import {
   normalizeOpenLibraryWorkId,
 } from '@app/utils/apiPath';
 import defineMessages from '@app/utils/defineMessages';
+import {
+  getTmdbPosterImageUrl,
+  getTmdbPosterImageVariants,
+} from '@app/utils/imageCache';
 import { getSafeHref } from '@app/utils/safeUrl';
 import { Transition } from '@headlessui/react';
 import {
@@ -260,7 +264,7 @@ const IssueDetails = () => {
     isMusic(data) || isBook(data)
       ? data.posterPath
       : data.posterPath
-        ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+        ? getTmdbPosterImageUrl(data.posterPath)
         : undefined;
   const backdropPath = isMusic(data)
     ? data.artistBackdrop
@@ -357,6 +361,11 @@ const IssueDetails = () => {
           <CachedImage
             type={isBook(data) ? 'book' : isMusic(data) ? 'music' : 'tmdb'}
             src={posterPath ?? '/images/seerr_poster_not_found.png'}
+            variants={
+              !isMusic(data) && !isBook(data)
+                ? getTmdbPosterImageVariants(data.posterPath)
+                : undefined
+            }
             alt=""
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}

--- a/src/components/MediaSlider/ShowMoreCard/index.tsx
+++ b/src/components/MediaSlider/ShowMoreCard/index.tsx
@@ -1,6 +1,7 @@
 import CachedImage from '@app/components/Common/CachedImage';
 import Placeholder from '@app/components/TitleCard/Placeholder';
 import defineMessages from '@app/utils/defineMessages';
+import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
 import { memo, useMemo } from 'react';
@@ -27,9 +28,7 @@ const getImageProps = (poster: string) => {
 
   return {
     type: 'tmdb' as const,
-    src: poster.startsWith('http')
-      ? poster
-      : `https://image.tmdb.org/t/p/w300_and_h450_face${poster}`,
+    src: getTmdbPosterImageUrl(poster),
   };
 };
 

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -30,7 +30,10 @@ import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
 import defineMessages from '@app/utils/defineMessages';
-import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
+import {
+  getTmdbPosterImageUrl,
+  getTmdbPosterImageVariants,
+} from '@app/utils/imageCache';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import { getSafeHref } from '@app/utils/safeUrl';
 import {
@@ -525,6 +528,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                 ? getTmdbPosterImageUrl(data.posterPath)
                 : '/images/seerr_poster_not_found.png'
             }
+            variants={getTmdbPosterImageVariants(data.posterPath)}
             alt=""
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}

--- a/src/components/PersonCard/index.tsx
+++ b/src/components/PersonCard/index.tsx
@@ -1,4 +1,5 @@
 import CachedImage from '@app/components/Common/CachedImage';
+import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
 import { UserCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -53,7 +54,10 @@ const PersonCard = ({
                 <div className="relative h-full w-3/4 overflow-hidden rounded-full ring-1 ring-gray-700">
                   <CachedImage
                     type="tmdb"
-                    src={`https://image.tmdb.org/t/p/w600_and_h900_bestv2${profilePath}`}
+                    src={getTmdbPosterImageUrl(
+                      profilePath,
+                      'w600_and_h900_bestv2'
+                    )}
                     alt=""
                     style={{
                       width: '100%',

--- a/src/components/RequestModal/CollectionRequestModal.tsx
+++ b/src/components/RequestModal/CollectionRequestModal.tsx
@@ -11,6 +11,7 @@ import globalMessages from '@app/i18n/globalMessages';
 import { getCoveredCollectionPartIds } from '@app/utils/collectionRequestState';
 import { mapWithConcurrency } from '@app/utils/concurrency';
 import defineMessages from '@app/utils/defineMessages';
+import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import type { MediaRequest } from '@server/entity/MediaRequest';
 import type { QuotaResponse } from '@server/interfaces/api/userInterfaces';
@@ -512,7 +513,7 @@ const CollectionRequestModal = ({
                                 type="tmdb"
                                 src={
                                   part.posterPath
-                                    ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${part.posterPath}`
+                                    ? getTmdbPosterImageUrl(part.posterPath)
                                     : '/images/seerr_poster_not_found.png'
                                 }
                                 alt=""

--- a/src/components/ServiceWorkerSetup/sw.test.ts
+++ b/src/components/ServiceWorkerSetup/sw.test.ts
@@ -34,6 +34,8 @@ const createHarness = () => {
   const listeners = new Map<string, Listener>();
   const cacheStores = new Map<string, MemoryCache>();
   const networkResponses: (Response | Error)[] = [];
+  const networkRequests: string[] = [];
+  let now = Date.UTC(2026, 8, 9);
   const shownNotifications: { subject: string; options: unknown }[] = [];
   const openedWindows: string[] = [];
 
@@ -71,8 +73,14 @@ const createHarness = () => {
         },
       },
       console,
+      Date: class extends Date {
+        static now() {
+          return now;
+        }
+      },
       encodeURIComponent,
-      fetch: async () => {
+      fetch: async (request: Request) => {
+        networkRequests.push(request.url);
         const nextResponse = networkResponses.shift();
         if (nextResponse instanceof Error) {
           throw nextResponse;
@@ -156,11 +164,16 @@ const createHarness = () => {
 
   return {
     activate,
+    advanceTime: (milliseconds: number) => {
+      now += milliseconds;
+    },
     cacheNames: () => [...cacheStores.keys()],
     clickNotification,
     dispatchPush,
     fetchRequest,
+    networkRequests,
     networkResponses,
+    now: () => now,
     openedWindows,
     seedCache: (name: string) => caches.open(name),
     setUser,
@@ -351,6 +364,279 @@ describe('service worker runtime cache', () => {
       await (await harness.fetchRequest(request))?.text(),
       'manager-data'
     );
+  });
+});
+
+describe('service worker public artwork reuse', () => {
+  const artworkRequest = new Request(
+    'https://seerr.test/imageproxy/tmdb/t/p/w342/poster.jpg'
+  );
+  const artworkResponse = (
+    body = 'poster',
+    headers: Record<string, string> = {}
+  ) =>
+    new Response(body, {
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'Cache-Control': 'public, max-age=3600',
+        ...headers,
+      },
+    });
+
+  it('reuses a downloaded public image without fetching during navigation or user changes', async () => {
+    const harness = createHarness();
+    harness.networkResponses.push(artworkResponse());
+    await harness.setUser(1, 2);
+    assert.equal(
+      await (await harness.fetchRequest(artworkRequest))?.text(),
+      'poster'
+    );
+    const requestsAfterDownload = harness.networkRequests.length;
+
+    for (const user of [1, 2, null]) {
+      await harness.setUser(user);
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'poster'
+      );
+    }
+
+    assert.equal(harness.networkRequests.length - requestsAfterDownload, 0);
+  });
+
+  it('honors a shorter max-age and waits for an expired image to refresh', async () => {
+    const harness = createHarness();
+    harness.networkResponses.push(
+      artworkResponse('original', { 'Cache-Control': 'public, max-age="60"' })
+    );
+    await harness.fetchRequest(artworkRequest);
+
+    harness.advanceTime(59000);
+    assert.equal(
+      await (await harness.fetchRequest(artworkRequest))?.text(),
+      'original'
+    );
+    assert.equal(harness.networkRequests.length, 1);
+
+    harness.advanceTime(1000);
+    harness.networkResponses.push(artworkResponse('updated'));
+    assert.equal(
+      await (await harness.fetchRequest(artworkRequest))?.text(),
+      'updated'
+    );
+    assert.equal(harness.networkRequests.length, 2);
+  });
+
+  it('honors explicit request cache bypasses even when artwork is fresh', async () => {
+    for (const cache of ['reload', 'no-cache', 'no-store'] as const) {
+      const harness = createHarness();
+      harness.networkResponses.push(artworkResponse('original'));
+      await harness.fetchRequest(artworkRequest);
+      harness.networkResponses.push(artworkResponse('updated'));
+      assert.equal(
+        await (
+          await harness.fetchRequest(new Request(artworkRequest, { cache }))
+        )?.text(),
+        'updated'
+      );
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('caps long or missing max-age at the existing 24-hour policy', async () => {
+    for (const cacheControl of ['public, max-age=31536000', 'public']) {
+      const harness = createHarness();
+      harness.networkResponses.push(
+        artworkResponse('original', { 'Cache-Control': cacheControl })
+      );
+      await harness.fetchRequest(artworkRequest);
+      harness.advanceTime(24 * 60 * 60 * 1000 - 1);
+      await harness.fetchRequest(artworkRequest);
+      assert.equal(harness.networkRequests.length, 1);
+
+      harness.advanceTime(1);
+      harness.networkResponses.push(artworkResponse('updated'));
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'updated'
+      );
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('preserves upstream Age and Date instead of restarting freshness on insertion', async () => {
+    const cases: Record<string, string>[] = [
+      { Age: '40' },
+      { Date: new Date(Date.UTC(2026, 8, 8, 23, 59, 20)).toUTCString() },
+      {
+        Age: '40',
+        Date: new Date(Date.UTC(2026, 8, 8, 23, 59, 50)).toUTCString(),
+      },
+    ];
+    for (const metadata of cases) {
+      const harness = createHarness();
+      harness.networkResponses.push(
+        artworkResponse('original', {
+          'Cache-Control': 'public, max-age=60',
+          ...metadata,
+        })
+      );
+      await harness.fetchRequest(artworkRequest);
+      harness.advanceTime(19000);
+      await harness.fetchRequest(artworkRequest);
+      assert.equal(harness.networkRequests.length, 1);
+
+      harness.advanceTime(1000);
+      harness.networkResponses.push(artworkResponse('updated'));
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'updated'
+      );
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('requires valid freshness metadata before skipping a fetch', async () => {
+    const cases: Record<string, string>[] = [
+      { 'Cache-Control': 'public, max-age=0' },
+      { 'Cache-Control': 'public, max-age=-1' },
+      { 'Cache-Control': 'public, max-age=invalid' },
+      { 'Cache-Control': 'public, max-age=60, max-age=3600' },
+      { 'Cache-Control': 'public, max-age="60' },
+      { Age: '-1' },
+      { Age: 'invalid' },
+      { Age: '3600' },
+      { Date: 'invalid' },
+    ];
+    for (const metadata of cases) {
+      const harness = createHarness();
+      harness.networkResponses.push(artworkResponse('original', metadata));
+      await harness.fetchRequest(artworkRequest);
+      harness.networkResponses.push(artworkResponse('updated'));
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'updated'
+      );
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('requires a valid insertion timestamp in an existing compatible cache', async () => {
+    for (const timestamp of [undefined, '', 'invalid', '-1', '9999999999999']) {
+      const harness = createHarness();
+      const cache = await harness.seedCache('seerrng-static-v1');
+      await cache.put(
+        artworkRequest,
+        artworkResponse('original', {
+          ...(timestamp === undefined
+            ? {}
+            : { 'x-seerrng-cache-time': timestamp }),
+        })
+      );
+      harness.networkResponses.push(artworkResponse('updated'));
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'updated'
+      );
+      assert.equal(harness.networkRequests.length, 1);
+    }
+  });
+
+  it('excludes private, no-store, no-cache, implicit-public, and non-image responses from the shortcut', async () => {
+    const cases: Record<string, string>[] = [
+      { 'Cache-Control': 'private, max-age=3600' },
+      { 'Cache-Control': 'public, private="Set-Cookie", max-age=3600' },
+      { 'Cache-Control': 'public, no-store, max-age=3600' },
+      { 'Cache-Control': 'public, no-cache, max-age=3600' },
+      { 'Cache-Control': 'max-age=3600' },
+      { 'Content-Type': 'text/html' },
+      { Vary: '*' },
+    ];
+    for (const headers of cases) {
+      const harness = createHarness();
+      harness.networkResponses.push(artworkResponse('original', headers));
+      await harness.fetchRequest(artworkRequest);
+      harness.networkResponses.push(artworkResponse('updated', headers));
+      await harness.fetchRequest(artworkRequest);
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('does not extend cache-first behavior to avatars, static files, or authenticated APIs', async () => {
+    for (const path of [
+      '/avatarproxy/gravatar/avatar.jpg',
+      '/poster.jpg',
+      '/api/v1/book/42/cover.jpg',
+    ]) {
+      const harness = createHarness();
+      await harness.setUser(1);
+      const request = new Request(`https://seerr.test${path}`);
+      harness.networkResponses.push(artworkResponse('original'));
+      await harness.fetchRequest(request);
+      harness.networkResponses.push(artworkResponse('updated'));
+      await harness.fetchRequest(request);
+      assert.equal(harness.networkRequests.length, 2);
+    }
+  });
+
+  it('keeps provider, artwork, size, and version query URLs distinct', async () => {
+    const harness = createHarness();
+    const paths = [
+      '/imageproxy/tmdb/t/p/w342/poster.jpg',
+      '/imageproxy/tmdb/t/p/w780/poster.jpg',
+      '/imageproxy/tmdb/t/p/w342/another.jpg',
+      '/imageproxy/openlibrary/b/id/42-L.jpg',
+      '/imageproxy/openlibrary/b/id/43-L.jpg',
+      '/imageproxy/openlibrary/b/id/42-L.jpg?version=1',
+      '/imageproxy/openlibrary/b/id/42-L.jpg?version=2',
+    ];
+    for (const path of paths) {
+      harness.networkResponses.push(artworkResponse(path));
+      await harness.fetchRequest(new Request(`https://seerr.test${path}`));
+    }
+    assert.equal(harness.networkRequests.length, paths.length);
+
+    for (const path of paths) {
+      assert.equal(
+        await (
+          await harness.fetchRequest(new Request(`https://seerr.test${path}`))
+        )?.text(),
+        path
+      );
+    }
+    assert.equal(harness.networkRequests.length, paths.length);
+  });
+
+  it('retains expired images on network failures but evicts them after terminal errors', async () => {
+    const harness = createHarness();
+    harness.networkResponses.push(
+      artworkResponse('original', { 'Cache-Control': 'public, max-age=1' })
+    );
+    await harness.fetchRequest(artworkRequest);
+    harness.advanceTime(1000);
+
+    for (const failure of [
+      new Error('offline'),
+      new Response('unavailable', { status: 503 }),
+    ]) {
+      harness.networkResponses.push(failure);
+      assert.equal(
+        await (await harness.fetchRequest(artworkRequest))?.text(),
+        'original'
+      );
+    }
+
+    harness.networkResponses.push(new Response('missing', { status: 404 }));
+    assert.equal(
+      await (await harness.fetchRequest(artworkRequest))?.text(),
+      'missing'
+    );
+    harness.networkResponses.push(new Error('offline'));
+    assert.notEqual(
+      await (await harness.fetchRequest(artworkRequest))?.text(),
+      'original'
+    );
+    assert.equal(harness.networkRequests.length, 5);
   });
 });
 

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -425,7 +425,7 @@ const TitleCard = ({
                     : undefined,
                 }
               : `/artist/${encodeApiPathSegment(canonicalId)}`;
-  const displayImage = getTmdbPosterImageUrl(image, 'w300_and_h450_face');
+  const displayImage = getTmdbPosterImageUrl(image);
   const imageCacheType =
     isResolvedImageUrl(displayImage) && isBook
       ? 'book'

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -32,7 +32,10 @@ import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
 import defineMessages from '@app/utils/defineMessages';
-import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
+import {
+  getTmdbPosterImageUrl,
+  getTmdbPosterImageVariants,
+} from '@app/utils/imageCache';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import { getSafeHref } from '@app/utils/safeUrl';
 import { Disclosure, Transition } from '@headlessui/react';
@@ -572,6 +575,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 ? getTmdbPosterImageUrl(data.posterPath)
                 : '/images/seerr_poster_not_found.png'
             }
+            variants={getTmdbPosterImageVariants(data.posterPath)}
             alt=""
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}

--- a/src/hooks/useImageVariants.test.ts
+++ b/src/hooks/useImageVariants.test.ts
@@ -1,0 +1,558 @@
+import CachedImage from '@app/components/Common/CachedImage';
+import { loadedImages } from '@app/utils/loadedImages';
+import { JSDOM } from 'jsdom';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { act, createElement, type SyntheticEvent } from 'react';
+import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import useImageVariants from './useImageVariants';
+
+let dom: JSDOM;
+let root: Root | undefined;
+let nextFamily = 0;
+let family: string;
+let downloads: UpgradeImage[];
+let dimensions: Map<string, { width: number; height: number }>;
+let box: { top: number; left: number; width: number; height: number };
+let observers: (() => void)[];
+let disconnected: number;
+let dprListeners: Set<() => void>;
+
+class UpgradeImage {
+  src = '';
+  decoding = '';
+  naturalWidth = 780;
+  naturalHeight = 1170;
+  onload: (() => Promise<void>) | null = null;
+  onerror: (() => void) | null = null;
+  decode: () => Promise<void> = async () => undefined;
+  constructor() {
+    downloads.push(this);
+  }
+}
+
+const variantsFor = (id: string) =>
+  [342, 500, 780].map((width) => ({ src: `/${id}/w${width}`, width }));
+const Probe = ({
+  id = family,
+  enabled = true,
+  singleSource = false,
+}: {
+  id?: string;
+  enabled?: boolean;
+  singleSource?: boolean;
+}) => {
+  const variant = useImageVariants(
+    `/${id}/w342`,
+    singleSource ? undefined : variantsFor(id),
+    enabled
+  );
+  return createElement('img', {
+    src: variant.src,
+    ref: variant.ref,
+    loading: 'lazy',
+    alt: 'Poster',
+    style: { objectFit: 'cover' },
+    onLoad: (event: SyntheticEvent<HTMLImageElement>) =>
+      variant.onLoad(event.currentTarget),
+  });
+};
+const imageSrc = () =>
+  dom.window.document.querySelector('img')?.getAttribute('src');
+const record = (width: number, id = family) => {
+  const src = `/${id}/w${width}`;
+  const size = { width, height: width * 1.5 };
+  dimensions.set(src, size);
+  loadedImages.record(src, size.width, size.height);
+};
+const render = async (id = family) => {
+  root ??= createRoot(dom.window.document.getElementById('root')!);
+  await act(async () => root?.render(createElement(Probe, { id })));
+};
+const resize = async (width: number, dpr = dom.window.devicePixelRatio) => {
+  box.width = width;
+  box.height = width * 1.5;
+  Object.defineProperty(dom.window, 'devicePixelRatio', {
+    value: dpr,
+    configurable: true,
+  });
+  await act(async () => {
+    dom.window.dispatchEvent(new dom.window.Event('resize'));
+  });
+};
+const finishUpgrade = async (index = 0) => {
+  const download = downloads[index];
+  const width = Number(download.src.split('/w')[1]);
+  download.naturalWidth = width;
+  download.naturalHeight = width * 1.5;
+  dimensions.set(download.src, { width, height: width * 1.5 });
+  await act(async () => download.onload?.());
+};
+
+beforeEach(() => {
+  family = `artwork-${nextFamily++}`;
+  downloads = [];
+  dimensions = new Map();
+  observers = [];
+  disconnected = 0;
+  dprListeners = new Set();
+  box = { top: 0, left: 0, width: 128, height: 192 };
+  dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost' });
+  Object.defineProperty(globalThis, 'window', {
+    value: dom.window,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    value: dom.window.document,
+    configurable: true,
+  });
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(dom.window, 'devicePixelRatio', {
+    value: 2,
+    configurable: true,
+  });
+  dom.window.Image = UpgradeImage as unknown as typeof Image;
+  const Observer = class {
+    constructor(callback: () => void) {
+      observers.push(callback);
+    }
+    observe() {}
+    disconnect() {
+      disconnected++;
+    }
+  };
+  dom.window.ResizeObserver = Observer as unknown as typeof ResizeObserver;
+  dom.window.IntersectionObserver =
+    Observer as unknown as typeof IntersectionObserver;
+  dom.window.matchMedia = () =>
+    ({
+      addEventListener: (_: string, listener: () => void) =>
+        dprListeners.add(listener),
+      removeEventListener: (_: string, listener: () => void) =>
+        dprListeners.delete(listener),
+    }) as unknown as MediaQueryList;
+  const prototype = dom.window.HTMLImageElement.prototype;
+  const getDimensions = (image: HTMLImageElement) => {
+    const url = new URL(image.src);
+    return (
+      dimensions.get(image.getAttribute('src')!) ??
+      dimensions.get(url.pathname + url.search)
+    );
+  };
+  Object.defineProperties(prototype, {
+    naturalWidth: {
+      get() {
+        return getDimensions(this)?.width ?? 0;
+      },
+      configurable: true,
+    },
+    naturalHeight: {
+      get() {
+        return getDimensions(this)?.height ?? 0;
+      },
+      configurable: true,
+    },
+    clientWidth: {
+      get() {
+        return box.width;
+      },
+      configurable: true,
+    },
+    clientHeight: {
+      get() {
+        return box.height;
+      },
+      configurable: true,
+    },
+    complete: {
+      get() {
+        return !!getDimensions(this);
+      },
+      configurable: true,
+    },
+  });
+  prototype.getBoundingClientRect = () => ({
+    ...box,
+    x: box.left,
+    y: box.top,
+    right: box.left + box.width,
+    bottom: box.top + box.height,
+    toJSON: () => undefined,
+  });
+});
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  root = undefined;
+  // Settle any intentionally abandoned upgrade; production requests are shared
+  // across mounts and continue until their own bounded timeout.
+  for (const download of downloads) download.onerror?.();
+  await Promise.resolve();
+  dom.window.close();
+  Reflect.deleteProperty(globalThis, 'window');
+  Reflect.deleteProperty(globalThis, 'document');
+});
+
+describe('progressive artwork lifecycle', () => {
+  it('keeps a loaded 342px thumbnail at 128 CSS pixels and DPR 2', async () => {
+    record(342);
+    await render();
+    assert.equal(imageSrc(), `/${family}/w342`);
+    assert.equal(downloads.length, 0);
+  });
+
+  it('keeps the thumbnail visible until the single sufficient upgrade decodes', async () => {
+    record(342);
+    box.width = 208;
+    box.height = 312;
+    Object.defineProperty(dom.window, 'devicePixelRatio', {
+      value: 3,
+      configurable: true,
+    });
+    await render();
+    assert.equal(imageSrc(), `/${family}/w342`);
+    assert.equal(downloads.length, 1);
+    assert.equal(downloads[0].src, `/${family}/w780`);
+    let finishDecode: (() => void) | undefined;
+    downloads[0].decode = () =>
+      new Promise((resolve) => {
+        finishDecode = resolve;
+      });
+    const loading = downloads[0].onload?.();
+    await act(async () => Promise.resolve());
+    assert.equal(imageSrc(), `/${family}/w342`);
+    await act(async () => {
+      finishDecode?.();
+      await loading;
+    });
+    assert.equal(imageSrc(), `/${family}/w780`);
+    await resize(80, 1);
+    assert.equal(imageSrc(), `/${family}/w780`);
+    assert.equal(downloads.length, 1);
+  });
+
+  it('reuses an already loaded larger variant on the first client render', async () => {
+    record(780);
+    await render();
+    assert.equal(imageSrc(), `/${family}/w780`);
+    assert.equal(downloads.length, 0);
+  });
+
+  it('keeps cold SSR and hydration deterministic and waits for the base image', async () => {
+    const serverHtml = renderToString(createElement(Probe));
+    assert.match(serverHtml, new RegExp(`src="/${family}/w342"`));
+    dom.window.document.getElementById('root')!.innerHTML = serverHtml;
+    const errors: unknown[] = [];
+    await act(async () => {
+      root = hydrateRoot(
+        dom.window.document.getElementById('root')!,
+        createElement(Probe),
+        { onRecoverableError: (error) => errors.push(error) }
+      );
+    });
+    await resize(208, 3);
+    assert.equal(downloads.length, 0);
+    dimensions.set(`/${family}/w342`, { width: 342, height: 513 });
+    await act(async () =>
+      dom.window.document
+        .querySelector('img')!
+        .dispatchEvent(new dom.window.Event('load'))
+    );
+    assert.equal(downloads.length, 1);
+    assert.equal(imageSrc(), `/${family}/w342`);
+    assert.deepEqual(errors, []);
+    await finishUpgrade();
+  });
+
+  it('hydrates the base without mismatching even when a larger variant is already known', async () => {
+    record(342);
+    record(780);
+    const serverHtml = renderToString(createElement(Probe));
+    assert.match(serverHtml, new RegExp(`src="/${family}/w342"`));
+    dom.window.document.getElementById('root')!.innerHTML = serverHtml;
+    const errors: unknown[] = [];
+    await act(async () => {
+      root = hydrateRoot(
+        dom.window.document.getElementById('root')!,
+        createElement(Probe),
+        { onRecoverableError: (error) => errors.push(error) }
+      );
+    });
+    assert.deepEqual(errors, []);
+    assert.equal(imageSrc(), `/${family}/w780`);
+    assert.equal(downloads.length, 0);
+  });
+
+  it('deduplicates concurrent consumers and ignores inline array recreation', async () => {
+    record(342);
+    box.width = 208;
+    box.height = 312;
+    root = createRoot(dom.window.document.getElementById('root')!);
+    const content = () =>
+      createElement('div', {}, createElement(Probe), createElement(Probe));
+    await act(async () => root?.render(content()));
+    await act(async () => root?.render(content()));
+    assert.equal(downloads.length, 1);
+    assert.equal(downloads[0].src, `/${family}/w500`);
+    await finishUpgrade();
+    assert.deepEqual(
+      Array.from(dom.window.document.querySelectorAll('img')).map((image) =>
+        image.getAttribute('src')
+      ),
+      [`/${family}/w500`, `/${family}/w500`]
+    );
+  });
+
+  it('retains the thumbnail on upgrade failure without a resize retry storm', async () => {
+    record(342);
+    await render();
+    await resize(208, 3);
+    await act(async () => downloads[0].onerror?.());
+    await resize(209, 3);
+    await resize(208, 3);
+    assert.equal(downloads.length, 1);
+    assert.equal(imageSrc(), `/${family}/w342`);
+  });
+
+  it('ignores completion for replaced artwork', async () => {
+    record(342);
+    await render();
+    await resize(208, 3);
+    const next = `${family}-edition-2`;
+    record(342, next);
+    await resize(128, 2);
+    await render(next);
+    assert.equal(imageSrc(), `/${next}/w342`);
+    await finishUpgrade();
+    assert.equal(imageSrc(), `/${next}/w342`);
+  });
+
+  it('does not upgrade offscreen images until the intersection changes', async () => {
+    record(342);
+    box.top = 4000;
+    box.width = 208;
+    box.height = 312;
+    await render();
+    assert.equal(downloads.length, 0);
+    assert.equal(
+      dom.window.document.querySelector('img')?.getAttribute('loading'),
+      'lazy'
+    );
+    box.top = 0;
+    await act(async () => {
+      for (const observer of observers) observer();
+    });
+    assert.equal(downloads.length, 1);
+    await finishUpgrade();
+  });
+
+  it('does not upgrade a sufficient poster solely because of a hover transform', async () => {
+    record(342);
+    dom.window.HTMLImageElement.prototype.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 256,
+      bottom: 384,
+      width: 256,
+      height: 384,
+      toJSON: () => undefined,
+    });
+    await render();
+    assert.equal(downloads.length, 0);
+    assert.equal(imageSrc(), `/${family}/w342`);
+  });
+
+  it('registers single-source artwork without allocating upgrade observers', async () => {
+    dimensions.set(`/${family}/w342`, { width: 342, height: 513 });
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () =>
+      root?.render(createElement(Probe, { singleSource: true }))
+    );
+    assert.equal(loadedImages.get(`/${family}/w342`)?.width, 342);
+    assert.equal(observers.length, 0);
+    assert.equal(dprListeners.size, 0);
+    await resize(800, 4);
+    assert.equal(downloads.length, 0);
+  });
+
+  it('responds to DPR and box changes and removes observers on unmount', async () => {
+    record(342);
+    await render();
+    Object.defineProperty(dom.window, 'devicePixelRatio', {
+      value: 4,
+      configurable: true,
+    });
+    await act(async () => {
+      for (const listener of [...dprListeners]) listener();
+    });
+    assert.equal(downloads[0].src, `/${family}/w780`);
+    await finishUpgrade();
+    await act(async () => root?.unmount());
+    root = undefined;
+    assert.ok(disconnected >= 2);
+    assert.equal(dprListeners.size, 0);
+  });
+});
+
+describe('CachedImage integration', () => {
+  const providerUrl = (id: string, width: number) =>
+    `https://image.tmdb.org/t/p/w${width}/${id}.jpg`;
+  const proxyUrl = (id: string, width: number) =>
+    `/imageproxy/tmdb/t/p/w${width}/${id}.jpg`;
+
+  it('resolves and reuses previously loaded provider variants through Next Image', async () => {
+    const src = proxyUrl(family, 780);
+    dimensions.set(src, { width: 780, height: 1170 });
+    loadedImages.record(src, 780, 1170);
+    let loaded = 0;
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () =>
+      root?.render(
+        createElement(CachedImage, {
+          src: providerUrl(family, 342),
+          type: 'tmdb',
+          width: 128,
+          height: 192,
+          alt: 'Poster',
+          variants: [342, 500, 780].map((width) => ({
+            src: providerUrl(family, width),
+            width,
+          })),
+          onLoad: () => {
+            loaded++;
+          },
+        })
+      )
+    );
+    assert.equal(imageSrc(), new URL(src, dom.window.location.href).href);
+    assert.equal(loadedImages.get(src)?.width, 780);
+    assert.equal(
+      dom.window.document.querySelector('img')?.getAttribute('loading'),
+      'lazy'
+    );
+    assert.equal(downloads.length, 0);
+    assert.equal(loaded, 1);
+  });
+
+  it('registers a card by its declared proxy URL despite Next normalizing the DOM URL', async () => {
+    const src = proxyUrl(family, 342);
+    dimensions.set(src, { width: 342, height: 513 });
+    root = createRoot(dom.window.document.getElementById('root')!);
+    const props = {
+      src: providerUrl(family, 342),
+      type: 'tmdb' as const,
+      width: 128,
+      height: 192,
+      alt: 'Poster',
+    };
+    await act(async () => root?.render(createElement(CachedImage, props)));
+    assert.equal(loadedImages.get(src)?.width, 342);
+    await act(async () =>
+      root?.render(
+        createElement(CachedImage, {
+          ...props,
+          variants: [342, 500, 780].map((width) => ({
+            src: providerUrl(family, width),
+            width,
+          })),
+        })
+      )
+    );
+    assert.equal(imageSrc(), new URL(src, dom.window.location.href).href);
+    assert.equal(downloads.length, 0);
+  });
+
+  it('falls back if a remembered larger image was evicted and now fails to load', async () => {
+    const base = proxyUrl(family, 342);
+    const large = proxyUrl(family, 780);
+    dimensions.set(base, { width: 342, height: 513 });
+    loadedImages.record(base, 342, 513);
+    // Only metadata remains for the larger artwork, not browser image bytes.
+    loadedImages.record(large, 780, 1170);
+    let failures = 0;
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () =>
+      root?.render(
+        createElement(CachedImage, {
+          src: providerUrl(family, 342),
+          type: 'tmdb',
+          width: 128,
+          height: 192,
+          alt: 'Poster',
+          variants: [342, 500, 780].map((width) => ({
+            src: providerUrl(family, width),
+            width,
+          })),
+          onError: () => {
+            failures++;
+          },
+        })
+      )
+    );
+    assert.equal(imageSrc(), new URL(large, dom.window.location.href).href);
+    await act(async () =>
+      dom.window.document
+        .querySelector('img')!
+        .dispatchEvent(new dom.window.Event('error'))
+    );
+    assert.equal(
+      dom.window.document.querySelector('img')?.src,
+      new URL(base, dom.window.location.href).href
+    );
+    assert.equal(loadedImages.get(large), undefined);
+    assert.equal(loadedImages.isCoolingDown(large), true);
+    assert.equal(failures, 1);
+    await resize(208, 3);
+    assert.equal(downloads.length, 0);
+    assert.equal(
+      dom.window.document.querySelector('img')?.src,
+      new URL(base, dom.window.location.href).href
+    );
+  });
+
+  it('only emits the deterministic base URL for a cold priority poster', () => {
+    const html = renderToString(
+      createElement(CachedImage, {
+        src: providerUrl(family, 342),
+        type: 'tmdb',
+        width: 208,
+        height: 312,
+        alt: 'Poster',
+        priority: true,
+        variants: [342, 500, 780].map((width) => ({
+          src: providerUrl(family, width),
+          width,
+        })),
+      })
+    );
+    assert.ok(html.includes(proxyUrl(family, 342)));
+    assert.ok(!html.includes(proxyUrl(family, 500)));
+    assert.ok(!html.includes(proxyUrl(family, 780)));
+    assert.equal(downloads.length, 0);
+  });
+
+  it('keeps avatar placeholders and their failure behavior', async () => {
+    root = createRoot(dom.window.document.getElementById('root')!);
+    await act(async () =>
+      root?.render(
+        createElement(CachedImage, {
+          src: 'https://plex.tv/users/avatar',
+          type: 'avatar',
+          width: 40,
+          height: 40,
+          alt: 'Avatar',
+        })
+      )
+    );
+    assert.ok(dom.window.document.querySelector('svg'));
+    assert.equal(imageSrc(), undefined);
+    assert.equal(downloads.length, 1);
+    await act(async () => downloads[0].onerror?.());
+    assert.ok(dom.window.document.querySelector('svg'));
+    assert.equal(downloads.length, 1);
+  });
+});

--- a/src/hooks/useImageVariants.ts
+++ b/src/hooks/useImageVariants.ts
@@ -1,0 +1,212 @@
+import type { ImageVariant } from '@app/utils/loadedImages';
+import {
+  loadedImages,
+  requiredImageWidth,
+  selectImageUpgrade,
+} from '@app/utils/loadedImages';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+const subscribe = () => () => undefined;
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+const NO_VARIANTS: readonly ImageVariant[] = [];
+
+const matchesImageRequest = (image: HTMLImageElement, src: string) =>
+  (image.currentSrc || image.src) ===
+  new URL(src, image.ownerDocument.baseURI).href;
+
+/** Preserve native lazy loading while progressively upgrading visible artwork. */
+const useImageVariants = (
+  baseSrc: string,
+  variants: readonly ImageVariant[] = NO_VARIANTS,
+  enabled = true
+) => {
+  // Hydration must start with the same base URL as SSR. A new client navigation
+  // can reuse a loaded variant in its very first render.
+  const isClient = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot
+  );
+  // Call sites can declare variants inline without restarting pending work.
+  const candidateKey = JSON.stringify([
+    { src: baseSrc, width: 0 },
+    ...variants,
+  ]);
+  const candidates = useMemo<ImageVariant[]>(
+    () => JSON.parse(candidateKey),
+    [candidateKey]
+  );
+  const identity = `${enabled}:${candidateKey}`;
+  const initialSrc = () =>
+    (enabled && isClient && loadedImages.findLargest(candidates)?.src) ||
+    baseSrc;
+  const [selection, setSelection] = useState(() => ({
+    identity,
+    src: initialSrc(),
+  }));
+  // A changed artwork must never render the previous artwork, even for one
+  // commit. The identity also isolates in-flight completions from old props.
+  let activeSrc = selection.src;
+  if (selection.identity !== identity) {
+    activeSrc = initialSrc();
+    setSelection({ identity, src: activeSrc });
+  }
+  const [element, setElement] = useState<HTMLImageElement | null>(null);
+  const evaluateRef = useRef<(() => void) | undefined>(undefined);
+  const onLoad = useCallback(
+    (image: HTMLImageElement) => {
+      // Next Image can assign img.src to itself, making its DOM attribute
+      // absolute. Keep the declared resolved URL as the shared registry key.
+      if (matchesImageRequest(image, activeSrc)) {
+        loadedImages.record(activeSrc, image.naturalWidth, image.naturalHeight);
+        evaluateRef.current?.();
+      }
+    },
+    [activeSrc]
+  );
+
+  const onError = useCallback(
+    (image: HTMLImageElement) => {
+      if (!matchesImageRequest(image, activeSrc)) return;
+      // Metadata outlives the browser's byte cache. A remembered variant can fail
+      // when requested again; remove it before choosing a compatible fallback.
+      loadedImages.markFailed(activeSrc);
+      const fallback =
+        loadedImages.findLargest(candidates)?.src ??
+        (activeSrc !== baseSrc && !loadedImages.isCoolingDown(baseSrc)
+          ? baseSrc
+          : undefined);
+      if (fallback) {
+        setSelection((previous) =>
+          previous.identity === identity && previous.src === activeSrc
+            ? { identity, src: fallback }
+            : previous
+        );
+      }
+    },
+    [activeSrc, baseSrc, candidates, identity]
+  );
+
+  useEffect(() => {
+    if (!enabled || !isClient || !element) return;
+    if (candidates.length === 1) {
+      // Cards and single-source providers only register successful loads.
+      if (element.complete && element.naturalWidth > 0) onLoad(element);
+      return;
+    }
+    let disposed = false;
+    const requests = new Set<string>();
+    let mediaQuery: MediaQueryList | undefined;
+
+    const evaluate = () => {
+      if (disposed) return;
+      const rect = element.getBoundingClientRect();
+      if (
+        rect.width <= 0 ||
+        rect.height <= 0 ||
+        rect.bottom <= 0 ||
+        rect.right <= 0 ||
+        rect.top >= window.innerHeight ||
+        rect.left >= window.innerWidth
+      ) {
+        return;
+      }
+      const current =
+        loadedImages.get(activeSrc) ??
+        (element.complete && matchesImageRequest(element, activeSrc)
+          ? loadedImages.record(
+              activeSrc,
+              element.naturalWidth,
+              element.naturalHeight
+            )
+          : undefined);
+      // Wait for the base to load. Native loading="lazy" controls offscreen
+      // downloads; the thumbnail stays visible throughout upgrade decoding.
+      if (!current) return;
+      const requiredWidth = requiredImageWidth({
+        width: element.clientWidth,
+        height: element.clientHeight,
+        naturalWidth: current.width,
+        naturalHeight: current.height,
+        devicePixelRatio: window.devicePixelRatio,
+        objectFit: window.getComputedStyle(element).objectFit,
+      });
+      const cached = loadedImages.findLargest(candidates);
+      if (cached && cached.width > current.width) {
+        setSelection((previous) =>
+          previous.identity === identity && previous.src === activeSrc
+            ? { identity, src: cached.src }
+            : previous
+        );
+        return;
+      }
+      const upgrade = selectImageUpgrade(
+        candidates.filter(({ src }) => src !== activeSrc),
+        current.width,
+        requiredWidth
+      );
+      if (!upgrade || requests.has(upgrade.src)) return;
+      requests.add(upgrade.src);
+      void loadedImages.preload(upgrade.src).then((loaded) => {
+        requests.delete(upgrade.src);
+        if (disposed || !loaded || loaded.width <= current.width) return;
+        setSelection((previous) => {
+          if (previous.identity !== identity) return previous;
+          const previousWidth = loadedImages.get(previous.src)?.width ?? 0;
+          return loaded.width > previousWidth
+            ? { identity, src: loaded.src }
+            : previous;
+        });
+      });
+    };
+    evaluateRef.current = evaluate;
+    const observeDpr = () => {
+      mediaQuery?.removeEventListener('change', onDprChange);
+      mediaQuery = window.matchMedia?.(
+        `(resolution: ${window.devicePixelRatio || 1}dppx)`
+      );
+      mediaQuery?.addEventListener('change', onDprChange);
+    };
+    const onDprChange = () => {
+      observeDpr();
+      evaluate();
+    };
+    const resizeObserver = window.ResizeObserver
+      ? new window.ResizeObserver(evaluate)
+      : undefined;
+    resizeObserver?.observe(element);
+    const intersectionObserver = window.IntersectionObserver
+      ? new window.IntersectionObserver(evaluate)
+      : undefined;
+    intersectionObserver?.observe(element);
+    window.addEventListener('resize', evaluate);
+    if (!intersectionObserver) {
+      window.addEventListener('scroll', evaluate, true);
+    }
+    observeDpr();
+    if (element.complete && element.naturalWidth > 0) onLoad(element);
+    else evaluate();
+
+    return () => {
+      disposed = true;
+      evaluateRef.current = undefined;
+      resizeObserver?.disconnect();
+      intersectionObserver?.disconnect();
+      mediaQuery?.removeEventListener('change', onDprChange);
+      window.removeEventListener('resize', evaluate);
+      window.removeEventListener('scroll', evaluate, true);
+    };
+  }, [activeSrc, candidates, element, enabled, identity, isClient, onLoad]);
+
+  return { src: activeSrc, ref: setElement, onLoad, onError };
+};
+
+export default useImageVariants;

--- a/src/hooks/useWarmImageCache.test.ts
+++ b/src/hooks/useWarmImageCache.test.ts
@@ -7,6 +7,19 @@ import {
 } from './useWarmImageCache';
 
 describe('poster cache warming', () => {
+  it('preserves resolved video artwork and skips authenticated local covers', () => {
+    const src = 'https://artworks.thetvdb.com/banners/poster.jpg';
+    assert.deepEqual(getImageUrls({ mediaType: 'tv', posterPath: src }, true), [
+      src,
+    ]);
+    assert.deepEqual(
+      getImageUrls(
+        { mediaType: 'movie', posterPath: '/api/v1/movie/1/cover' },
+        true
+      ),
+      []
+    );
+  });
   it('warms only poster sources when posterOnly is enabled', () => {
     assert.deepEqual(
       getImageUrls(
@@ -19,7 +32,7 @@ describe('poster cache warming', () => {
         },
         true
       ),
-      ['https://image.tmdb.org/t/p/w300_and_h450_face/movie.jpg']
+      ['https://image.tmdb.org/t/p/w342/movie.jpg']
     );
   });
 

--- a/src/hooks/useWarmImageCache.ts
+++ b/src/hooks/useWarmImageCache.ts
@@ -1,4 +1,5 @@
 import useSettings from '@app/hooks/useSettings';
+import { getTmdbPosterImageUrl } from '@app/utils/imageCache';
 import axios from 'axios';
 import { useEffect, useMemo } from 'react';
 
@@ -40,7 +41,9 @@ export const getImageUrls = (
     item.posterPath &&
     ['movie', 'tv', 'person', 'collection'].includes(item.mediaType ?? '')
   ) {
-    urls.push(getTmdbImageUrl(item.posterPath, 'w300_and_h450_face'));
+    urls.push(
+      normalizeExternalImageUrl(getTmdbPosterImageUrl(item.posterPath))
+    );
   } else {
     urls.push(normalizeExternalImageUrl(item.posterPath));
   }

--- a/src/utils/imageCache.test.ts
+++ b/src/utils/imageCache.test.ts
@@ -6,8 +6,57 @@ import {
   getImageCacheUrl,
   getImageErrorFallback,
   getInitialImageUrl,
+  getTmdbPosterImageUrl,
+  getTmdbPosterImageVariants,
   isRemoteAvatarCacheUrlAllowed,
 } from './imageCache';
+
+describe('poster artwork identity', () => {
+  it('uses the same base URL for cards and compatible detail variants', () => {
+    const path = '/poster.jpg?version=2';
+    assert.equal(
+      getTmdbPosterImageUrl(path),
+      'https://image.tmdb.org/t/p/w342/poster.jpg?version=2'
+    );
+    assert.deepEqual(
+      getTmdbPosterImageVariants(path),
+      [342, 500, 780].map((width) => ({
+        src: `https://image.tmdb.org/t/p/w${width}${path}`,
+        width,
+      }))
+    );
+  });
+
+  it('preserves provider, edition, query, and explicit crop identities', () => {
+    for (const src of [
+      'https://artworks.thetvdb.com/banners/poster.jpg',
+      'https://covers.openlibrary.org/b/id/123-L.jpg',
+      'https://archive.org/download/album/cover_thumb250.jpg',
+      'https://image.tmdb.org/t/p/w300_and_h450_face/poster.jpg',
+      '/api/v1/book/OL123W/cover?mediaId=12&format=audiobook',
+      '/imageproxy/tmdb/t/p/w342/poster.jpg',
+      '/images/seerr_poster_not_found.png',
+    ]) {
+      assert.equal(getTmdbPosterImageUrl(src), src);
+      assert.equal(getTmdbPosterImageVariants(src), undefined);
+    }
+    assert.equal(getTmdbPosterImageUrl(undefined), undefined);
+    assert.equal(getTmdbPosterImageVariants(undefined), undefined);
+    assert.notDeepEqual(
+      getTmdbPosterImageVariants('/poster.jpg?version=1'),
+      getTmdbPosterImageVariants('/poster.jpg?version=2')
+    );
+  });
+
+  it('preserves resolved artist photos while supporting TMDB profile paths', () => {
+    const artist = 'https://r2.theaudiodb.com/images/media/artist/thumb.jpg';
+    assert.equal(getTmdbPosterImageUrl(artist, 'w600_and_h900_bestv2'), artist);
+    assert.equal(
+      getTmdbPosterImageUrl('/person.jpg', 'w600_and_h900_bestv2'),
+      'https://image.tmdb.org/t/p/w600_and_h900_bestv2/person.jpg'
+    );
+  });
+});
 
 describe('getInitialImageUrl', () => {
   it('shows the bundled default while avatars load', () => {

--- a/src/utils/imageCache.ts
+++ b/src/utils/imageCache.ts
@@ -1,3 +1,8 @@
+import {
+  TMDB_POSTER_BASE_SIZE,
+  TMDB_POSTER_WIDTHS,
+} from '@server/constants/images';
+
 export type CacheableImageType = 'tmdb' | 'avatar' | 'tvdb' | 'music' | 'book';
 
 export const AVATAR_FALLBACK_IMAGE = '/user-icon-192x192.png';
@@ -6,7 +11,8 @@ export const isResolvedImageUrl = (src?: string): boolean =>
   !!src &&
   (src.startsWith('http') ||
     src.startsWith('/images/') ||
-    src.startsWith('/api/'));
+    src.startsWith('/api/') ||
+    src.startsWith('/imageproxy/'));
 
 export function getTmdbPosterImageUrl(
   posterPath: string,
@@ -18,7 +24,7 @@ export function getTmdbPosterImageUrl(
 ): string | undefined;
 export function getTmdbPosterImageUrl(
   posterPath?: string,
-  size = 'w600_and_h900_bestv2'
+  size = TMDB_POSTER_BASE_SIZE
 ): string | undefined {
   if (!posterPath) {
     return undefined;
@@ -28,6 +34,19 @@ export function getTmdbPosterImageUrl(
     ? posterPath
     : `https://image.tmdb.org/t/p/${size}${posterPath}`;
 }
+
+// Only explicitly generated sizes of the same uncropped TMDB poster are
+// interchangeable. Already resolved artwork may use a different provider,
+// edition, or crop and must retain its exact URL.
+export const getTmdbPosterImageVariants = (
+  posterPath?: string
+): readonly { src: string; width: number }[] | undefined =>
+  posterPath && !isResolvedImageUrl(posterPath)
+    ? TMDB_POSTER_WIDTHS.map((width) => ({
+        src: getTmdbPosterImageUrl(posterPath, `w${width}`),
+        width,
+      }))
+    : undefined;
 
 export const getInitialImageUrl = (
   type: CacheableImageType,

--- a/src/utils/loadedImages.test.ts
+++ b/src/utils/loadedImages.test.ts
@@ -1,0 +1,166 @@
+import { JSDOM } from 'jsdom';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  LoadedImageRegistry,
+  requiredImageWidth,
+  selectImageUpgrade,
+} from './loadedImages';
+
+let dom: JSDOM;
+let requested: TestImage[];
+class TestImage {
+  src = '';
+  decoding = '';
+  naturalWidth = 500;
+  naturalHeight = 750;
+  onload: (() => Promise<void>) | null = null;
+  onerror: (() => void) | null = null;
+  decode: () => Promise<void> = async () => undefined;
+  constructor() {
+    requested.push(this);
+  }
+}
+
+beforeEach(() => {
+  requested = [];
+  dom = new JSDOM('');
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: dom.window,
+  });
+  dom.window.Image = TestImage as unknown as typeof Image;
+});
+afterEach(() => {
+  dom.window.close();
+  Reflect.deleteProperty(globalThis, 'window');
+});
+
+describe('loaded image metadata', () => {
+  it('never stores or returns image metadata on the server', () => {
+    Reflect.deleteProperty(globalThis, 'window');
+    const registry = new LoadedImageRegistry();
+    assert.equal(registry.record('/poster', 342, 513), undefined);
+    assert.equal(registry.get('/poster'), undefined);
+  });
+
+  it('expires idle entries after 30 minutes and retains only 512 by access', () => {
+    let now = 0;
+    const registry = new LoadedImageRegistry(() => now);
+    for (let index = 0; index < 512; index++) {
+      registry.record(`/poster-${index}`, 342, 513);
+    }
+    registry.get('/poster-0');
+    registry.record('/poster-new', 342, 513);
+    assert.equal(registry.get('/poster-1'), undefined);
+    assert.ok(registry.get('/poster-0'));
+    now += 29 * 60 * 1000;
+    registry.get('/poster-0');
+    now += 60 * 1000;
+    assert.equal(registry.get('/poster-2'), undefined);
+    assert.ok(registry.get('/poster-0'));
+    now += 30 * 60 * 1000;
+    assert.equal(registry.get('/poster-0'), undefined);
+  });
+
+  it('keeps editions, providers and version queries separate', () => {
+    const registry = new LoadedImageRegistry();
+    registry.record('/api/book/1/cover?version=1', 780, 1170);
+    registry.record('https://example.com/cover?version=1', 900, 1350);
+    registry.record('/api/book/2/cover?version=1', 900, 1350);
+    const actual = registry.record('/api/book/1/cover?version=2', 342, 513);
+    assert.equal(
+      registry.findLargest([
+        { src: '/api/book/1/cover?version=2', width: 342 },
+      ]),
+      actual
+    );
+    assert.equal(registry.record('/broken', 0, 0), undefined);
+    assert.equal(registry.record('/broken', NaN, 513), undefined);
+  });
+
+  it('deduplicates an upgrade through decode and records its natural dimensions', async () => {
+    const registry = new LoadedImageRegistry();
+    const first = registry.preload('/upgrade');
+    const second = registry.preload('/upgrade');
+    assert.equal(first, second);
+    assert.equal(requested.length, 1);
+    let finishDecode: (() => void) | undefined;
+    requested[0].decode = () =>
+      new Promise((resolve) => {
+        finishDecode = resolve;
+      });
+    const load = requested[0].onload?.();
+    assert.equal(registry.get('/upgrade'), undefined);
+    assert.equal(registry.preload('/upgrade'), first);
+    finishDecode?.();
+    await load;
+    assert.equal((await first)?.width, 500);
+    assert.equal((await second)?.height, 750);
+    assert.equal((await registry.preload('/upgrade'))?.src, '/upgrade');
+    assert.equal(requested.length, 1);
+    assert.equal(requested[0].onload, null);
+    assert.equal(requested[0].onerror, null);
+  });
+
+  it('retains failures for 60 seconds before allowing a new load', async () => {
+    let now = 0;
+    const registry = new LoadedImageRegistry(() => now);
+    const first = registry.preload('/failure');
+    requested[0].onerror?.();
+    assert.equal(await first, undefined);
+    assert.equal(await registry.preload('/failure'), undefined);
+    assert.equal(requested.length, 1);
+    now = 60_000;
+    const retry = registry.preload('/failure');
+    assert.equal(requested.length, 2);
+    await requested[1].onload?.();
+    assert.ok(await retry);
+  });
+
+  it('does not publish an image whose decode failed', async () => {
+    const registry = new LoadedImageRegistry();
+    const pending = registry.preload('/decode-failure');
+    requested[0].decode = async () => {
+      throw new Error('decode failed');
+    };
+    await requested[0].onload?.();
+    assert.equal(await pending, undefined);
+    assert.equal(registry.get('/decode-failure'), undefined);
+  });
+});
+
+describe('resolution selection', () => {
+  const variants = [
+    { src: '/w342', width: 342 },
+    { src: '/w500', width: 500 },
+    { src: '/w780', width: 780 },
+  ];
+  it('retains a sufficient thumbnail and selects only the needed upgrade', () => {
+    assert.equal(selectImageUpgrade(variants, 342, 128 * 2), undefined);
+    assert.equal(selectImageUpgrade(variants, 342, 208 * 2)?.width, 500);
+    assert.equal(selectImageUpgrade(variants, 342, 208 * 3)?.width, 780);
+    assert.equal(selectImageUpgrade(variants, 342, 2000)?.width, 780);
+    assert.equal(selectImageUpgrade(variants, 780, 2000), undefined);
+  });
+  it('uses the cropped height for cover and painted width for contain', () => {
+    const box = {
+      width: 128,
+      height: 400,
+      naturalWidth: 342,
+      naturalHeight: 513,
+      devicePixelRatio: 2,
+    };
+    assert.ok(
+      Math.abs(requiredImageWidth({ ...box, objectFit: 'cover' }) - 1600 / 3) <
+        0.0001
+    );
+    assert.equal(requiredImageWidth({ ...box, objectFit: 'contain' }), 256);
+    assert.ok(
+      Math.abs(
+        requiredImageWidth({ ...box, height: 100, objectFit: 'contain' }) -
+          400 / 3
+      ) < 0.0001
+    );
+  });
+});

--- a/src/utils/loadedImages.ts
+++ b/src/utils/loadedImages.ts
@@ -1,0 +1,188 @@
+/** Variants must be explicitly declared to contain the same, uncropped artwork. */
+export interface ImageVariant {
+  src: string;
+  width: number;
+}
+
+export interface LoadedImage {
+  src: string;
+  width: number;
+  height: number;
+  accessedAt: number;
+}
+
+const MAX_ENTRIES = 512;
+const IDLE_EXPIRY_MS = 30 * 60 * 1000;
+const FAILURE_COOLDOWN_MS = 60 * 1000;
+const LOAD_TIMEOUT_MS = 30 * 1000;
+
+/** Metadata only: the browser owns the image bytes and their cache lifetime. */
+export class LoadedImageRegistry {
+  private entries = new Map<string, LoadedImage>();
+  private pending = new Map<string, Promise<LoadedImage | undefined>>();
+  private failedUntil = new Map<string, number>();
+
+  constructor(private now: () => number = Date.now) {}
+
+  private prune() {
+    const now = this.now();
+    for (const [src, entry] of this.entries) {
+      if (now - entry.accessedAt >= IDLE_EXPIRY_MS) {
+        this.entries.delete(src);
+      }
+    }
+    for (const [src, until] of this.failedUntil) {
+      if (until <= now) this.failedUntil.delete(src);
+    }
+  }
+
+  get(src: string): LoadedImage | undefined {
+    if (typeof window === 'undefined') return;
+    this.prune();
+    const entry = this.entries.get(src);
+    if (!entry) return;
+    entry.accessedAt = this.now();
+    this.entries.delete(src);
+    this.entries.set(src, entry);
+    return entry;
+  }
+
+  record(src: string, width: number, height: number): LoadedImage | undefined {
+    if (
+      typeof window === 'undefined' ||
+      !Number.isFinite(width) ||
+      !Number.isFinite(height) ||
+      width <= 0 ||
+      height <= 0
+    ) {
+      return;
+    }
+    this.prune();
+    const entry = { src, width, height, accessedAt: this.now() };
+    this.entries.delete(src);
+    this.entries.set(src, entry);
+    this.failedUntil.delete(src);
+    while (this.entries.size > MAX_ENTRIES) {
+      this.entries.delete(this.entries.keys().next().value as string);
+    }
+    return entry;
+  }
+
+  isCoolingDown(src: string): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      (this.failedUntil.get(src) ?? 0) > this.now()
+    );
+  }
+
+  markFailed(src: string) {
+    if (typeof window === 'undefined') return;
+    this.entries.delete(src);
+    this.failedUntil.set(src, this.now() + FAILURE_COOLDOWN_MS);
+    while (this.failedUntil.size > MAX_ENTRIES) {
+      this.failedUntil.delete(this.failedUntil.keys().next().value as string);
+    }
+  }
+
+  /** Only the supplied URLs are compatible; query parameters remain significant. */
+  findLargest(variants: readonly ImageVariant[]): LoadedImage | undefined {
+    if (typeof window === 'undefined') return;
+    this.prune();
+    let largest: LoadedImage | undefined;
+    for (const { src } of variants) {
+      const entry = this.entries.get(src);
+      if (entry && (!largest || entry.width > largest.width)) largest = entry;
+    }
+    return largest ? this.get(largest.src) : undefined;
+  }
+
+  /** Share upgrade work until load and decode complete, including across views. */
+  preload(src: string): Promise<LoadedImage | undefined> {
+    if (typeof window === 'undefined') return Promise.resolve(undefined);
+    const loaded = this.get(src);
+    if (loaded) return Promise.resolve(loaded);
+    const pending = this.pending.get(src);
+    if (pending) return pending;
+    if (this.isCoolingDown(src)) {
+      return Promise.resolve(undefined);
+    }
+
+    const image = new window.Image();
+    const promise = new Promise<LoadedImage | undefined>((resolve) => {
+      let settled = false;
+      const finish = (success: boolean) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeout);
+        image.onload = null;
+        image.onerror = null;
+        const entry = success
+          ? this.record(src, image.naturalWidth, image.naturalHeight)
+          : undefined;
+        if (!entry) this.markFailed(src);
+        resolve(entry);
+      };
+      const timeout = window.setTimeout(() => finish(false), LOAD_TIMEOUT_MS);
+      image.decoding = 'async';
+      image.onload = async () => {
+        try {
+          if (image.decode) await image.decode();
+          finish(true);
+        } catch {
+          finish(false);
+        }
+      };
+      image.onerror = () => finish(false);
+      image.src = src;
+    });
+    this.pending.set(src, promise);
+    void promise.then(() => this.pending.delete(src));
+    return promise;
+  }
+}
+
+export const loadedImages = new LoadedImageRegistry();
+
+/** Account for both axes when object-fit: cover crops the rendered image. */
+export const requiredImageWidth = ({
+  width,
+  height,
+  naturalWidth,
+  naturalHeight,
+  devicePixelRatio,
+  objectFit,
+}: {
+  width: number;
+  height: number;
+  naturalWidth: number;
+  naturalHeight: number;
+  devicePixelRatio: number;
+  objectFit: string;
+}): number => {
+  const ratio = naturalHeight > 0 ? naturalWidth / naturalHeight : 0;
+  const heightWidth = height * ratio;
+  const renderedWidth =
+    objectFit === 'cover'
+      ? Math.max(width, heightWidth)
+      : objectFit === 'contain' && heightWidth > 0
+        ? Math.min(width, heightWidth)
+        : width;
+  return renderedWidth * Math.max(1, devicePixelRatio || 1);
+};
+
+export const selectImageUpgrade = (
+  variants: readonly ImageVariant[],
+  currentWidth: number,
+  requiredWidth: number
+): ImageVariant | undefined => {
+  if (currentWidth >= requiredWidth) return;
+  const larger = variants
+    .filter(
+      ({ width }) => Number.isFinite(width) && width > currentWidth && width > 0
+    )
+    .sort((a, b) => a.width - b.width);
+  return (
+    larger.find(({ width }) => width >= requiredWidth) ??
+    larger[larger.length - 1]
+  );
+};


### PR DESCRIPTION
## Description

Opening a media detail page now displays artwork already downloaded for its card. Movie, TV, and collection posters keep that image when it covers the displayed size at the device's pixel ratio; otherwise they retain it while one sufficient replacement loads and decodes.

Fresh public image-proxy cache entries return without a background fetch. Matching music discovery and detail covers share the provider's exact thumbnail URL. Books, audiobooks, albums, artists, and people register their existing sources without conflating different covers, editions, providers, or version queries.

**AI Disclosure:** Codex generated the implementation, tests, this description, and evidence tooling at the requester's direction. The requester approved the approach and PR publication. Human source review remains pending.

## How Has This Been Tested?

- GitHub Actions on final commit `bfe4d19f`: [Unit Tests](https://github.com/snapetech/seerrng/actions/runs/34406634471/job/102651055510) passed **1,844 tests with zero failures** (4 skipped). [Cypress](https://github.com/snapetech/seerrng/actions/runs/34406634467/job/102651055698) passed **82 tests with zero failures** across 20 spec files; 32 live-authentication audit tests were intentionally disabled in PR CI. All 12 applicable checks passed; four deployment-only jobs were skipped as expected.
- Final commit `bfe4d19f`, rebased onto current `main`: production build, client/server typechecks, lint, formatting, release-note preview, and all 15 focused test files passed. Standalone client suites passed 73/73; discovery/image-proxy route suites passed 88/88.
- Authenticated Chromium navigation on the final production build: all eight media types passed card → detail → back with service workers enabled and blocked (16 cases), with zero additional image-origin requests or bytes. Both high-DPI upgrade cases and both cold-entry cases passed; zero runtime/proxy errors.
- A 128-CSS-pixel poster at DPR 2 keeps its loaded 342-pixel source. A 208-CSS-pixel poster at DPR 3 retains that source while exactly one 780-pixel replacement downloads. Tests also cover hydration, resizing/DPR changes, offscreen loading, decoding, concurrent loads, failed upgrades, and artwork changes.
- The initial local full run hit eight unchanged filesystem permission assertions under the environment's `0077` umask. All 23 tests in the affected suites passed with `0022`; the subsequent full CI run above passed on the final commit.

[Verification details](https://github.com/EasyAsABC123/seerrng/blob/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/verification.md) · [final navigation matrix](https://github.com/EasyAsABC123/seerrng/blob/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/navigation-matrix.json)

## Screenshots / Logs (if applicable)

These captures show the actual local production build with deterministic catalog/artwork fixtures, not production catalog content. Image labels identify source resolution. Authentication completed before recording. Native browser caching stayed enabled; request/body-byte counters establish reuse independently of network-panel entries. Both recordings had service-worker control.

| Recording | What it shows |
| --- | --- |
| [All eight media types — MP4, 21 seconds](https://github.com/EasyAsABC123/seerrng/raw/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/mobile-all-media.mp4) | Card → detail → back reuses each exact source with zero extra image-origin requests/bytes. |
| [Poster upgrade — MP4, 9 seconds](https://github.com/EasyAsABC123/seerrng/raw/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/desktop-poster-upgrade.mp4) | The 342-pixel thumbnail remains visible through a 3.3-second response delay, then switches to 780 pixels after one download. |

<details>
<summary>Watch GIF previews</summary>

<img src="https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/mobile-all-media.gif" width="260" alt="Recording of artwork reuse for all eight media types" />

<img src="https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/desktop-poster-upgrade.gif" width="800" alt="Recording of the existing thumbnail remaining visible until the sharper poster loads" />

</details>

<details>
<summary>View five screenshots</summary>

All eight card types:

![Media grid](https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/01-media-grid.png)

Movie and audiobook detail reuse:

<img src="https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/02-mobile-movie-reuse.png" width="260" alt="Mobile movie keeps its 342-pixel poster" />
<img src="https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/03-mobile-audiobook-reuse.png" width="260" alt="Mobile audiobook keeps its edition cover" />

While the upgrade loads:

![Existing thumbnail during upgrade](https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/04-desktop-before-upgrade.png)

After decoding:

![Sharper poster after upgrade](https://raw.githubusercontent.com/EasyAsABC123/seerrng/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae/05-desktop-after-upgrade.png)

</details>

[All evidence and capture assertions](https://github.com/EasyAsABC123/seerrng/tree/e58164da80a0a39cdeb4218fdc8d5f0dd60a3aae). Media lives on a separate evidence branch, outside this PR's code diff; links use its immutable commit.

## Release Notes

- [x] I added a release-note fragment under `release-notes/`.
- [ ] This change is internal-only and does not need a user-facing release note.
- [x] The fragment includes audience, area, action, and breaking-change status.
- [x] I previewed the release text with `pnpm release-notes:preview`.

Fragment: `release-notes/fixed-artwork-navigation-reuse.md`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md) for scope, testing, release notes, and disclosure; human source review remains pending, and this description is AI-authored as disclosed above.
- [x] Disclosed any use of AI (see our [policy](https://github.com/snapetech/seerrng/blob/main/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly. No configuration or API documentation changes are required.
- [x] All new and existing tests passed. Full CI: 1,844 passed, 4 skipped, zero failures; standalone client suites: 73/73 passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` — no translation keys changed.
- [ ] Database migration (if required) — no database changes.

